### PR TITLE
Add Agora Cosmica under a new Education category

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The default categories are:
 | `utilities` | Utilities | 🛠️ |
 | `data` | Data & Analytics | 📊 |
 | `media` | Media | 🎬 |
+| `education` | Education | 🎓 |
 
 
 ---

--- a/tools.json
+++ b/tools.json
@@ -47,6 +47,12 @@
       "name": "Media",
       "icon": "🎬",
       "description": "Edit and create media in-browser"
+    },
+    {
+      "id": "education",
+      "name": "Education",
+      "icon": "🎓",
+      "description": "Learn and study without creating accounts"
     }
   ],
   "tools": [
@@ -1643,6 +1649,18 @@
       "github": "https://github.com/bitbof/klecks",
       "license": "MIT",
       "stars": 360,
+      "featured": false
+    },
+    {
+      "id": "agora-cosmica",
+      "name": "Agora Cosmica",
+      "description": "Learn from 30 historical figures through stories, dialogues, and AI conversation. Nonprofit, no signup.",
+      "url": "https://agoracosmica.org",
+      "category": "education",
+      "tags": ["education", "philosophy", "history", "ai-chat", "self-hosted"],
+      "github": "https://github.com/chipmates/agoracosmica",
+      "license": "AGPL-3.0",
+      "stars": 90,
       "featured": false
     }
   ]


### PR DESCRIPTION
Adds Agora Cosmica to the list. Closes #106.

As discussed in that issue, it does not fit the existing buckets well. Media is a stretch, and Privacy & Security is really for security tools rather than a product that happens to respect privacy. So this adds a small Education category as its natural home.

Changes are data and docs only, no code:
- `tools.json`: new `education` category and the Agora Cosmica entry under it
- `README.md`: the Education row added to the Categories table

I checked this will not affect the build: `category` is typed as a plain string, category icons come from the data, and the fallback data is only used on fetch failure, so adding a category and tool to `tools.json` is all that is needed.

About the tool: an open-source, nonprofit educational platform for learning from 30 historical figures through stories, dialogues, and AI conversation. It works fully without an account (30 messages a day, no signup), is bring-your-own-key, and self-hostable.

Happy to recategorize or adjust the wording if you would prefer. Thanks for keeping the list.
