### PR TITLE
feat: add Simple Icons (closes #212)

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -1722,6 +1722,18 @@
       "license": "MIT",
       "stars": 352,
       "featured": false
+    },
+    {
+      "id": "simple-icons",
+      "name": "Simple Icons",
+      "description": "Free SVG icons for popular brands. 3000+ icons, public domain, no signup.",
+      "url": "https://simpleicons.org/",
+      "category": "design",
+      "tags": ["icons", "svg", "branding", "icon-library", "open-source"],
+      "github": "https://github.com/simple-icons/simple-icons",
+      "license": "CC0-1.0",
+      "stars": 25272,
+      "featured": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
Adds Simple Icons to the directory.

- **Name**: Simple Icons
- **URL**: https://simpleicons.org/
- **GitHub**: https://github.com/simple-icons/simple-icons
- **Category**: `design` (existing category)
- **License**: CC0-1.0 (public domain)
- **Stars**: 25,272

## FckSignups fit
- **No signup**: browse and use icons directly at simpleicons.org
- **OSS license**: CC0-1.0 (public domain dedication)
- **GitHub repo**: linked above

## Closes
Closes #212