### PR TITLE
Add llms.txt and AGENTS.md so LLMs and coding agents can read the directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,66 @@
+# AGENTS.md
+
+Guidance for AI coding agents working on this repository.
+
+## What this project is
+
+NoSignups (formerly FckSignups) is an open-source directory of free tools that run in the browser, require no signup, and are open source. It is a React + TypeScript single-page app built with Vite, deployed at https://nosignups.net. The code is licensed GPL-3.0.
+
+## Commands
+
+```bash
+npm install        # install dependencies
+npm run dev        # start the Vite dev server
+npm run build      # type-check (tsc) and build to dist/
+npm run preview    # preview the production build
+```
+
+There is no test suite. `npm run build` is the correctness gate — it must pass (TypeScript strict compilation) before you commit.
+
+## Project layout
+
+- `tools.json` — the tool directory data (categories + tools). This is the heart of the project. In production the app fetches it from the raw GitHub URL of the `main` branch, so changes to it go live without a redeploy.
+- `src/` — the React app:
+  - `src/hooks/useTools.ts` — loads `tools.json` (dev path → prod raw URL → `src/constants/fallbackData.ts`), filtering and sorting.
+  - `src/components/` — UI components (Header, Controls, ToolGrid, ToolCard, Footer, Toast, Report).
+  - `src/hooks/useModal/` — the submit/suggest/report modal system; field definitions live in `src/constants/ModalConfigs.tsx`.
+  - `src/types/index.ts` — the `Tool`, `Category`, and `ToolsData` interfaces. Keep `tools.json` consistent with these.
+- `public/` — static files copied verbatim to the site root at build time (e.g. `llms.txt`).
+- `cloudflare-worker/` — a separate Cloudflare Worker that receives submit/suggest/report form posts and opens GitHub issues. It has its own `package.json` and is not part of the Vite build.
+- `management_tools/` — Python maintenance scripts (adding tools from issues, refreshing GitHub star counts).
+
+## Editing tools.json
+
+Each tool entry follows this schema (see also the README):
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `id` | Yes | URL-friendly unique identifier |
+| `name` | Yes | Display name |
+| `description` | Yes | One sentence, under 140 characters |
+| `url` | Yes | Direct link to the tool |
+| `category` | Yes | Must match a category `id` in the same file |
+| `tags` | No | 3–5 searchable keywords |
+| `github` | No | Source repository link |
+| `license` | No | SPDX identifier |
+| `stars` | No | GitHub star count |
+| `featured` | No | Boolean; pins to top |
+| `notRecommendedReason` | No | Why the entry is not recommended |
+
+Rules for adding a tool:
+
+- It must work **without creating an account** — this is the project's core promise.
+- It should run in the browser and be open source.
+- Keep the description under 140 characters and use 3–5 relevant tags.
+- Validate that the file is still valid JSON after editing.
+
+## Conventions
+
+- TypeScript strict mode; functional React components with hooks.
+- No CSS framework — styles live in `src/index.css`.
+- Keep dependencies minimal; this project deliberately avoids bloat.
+- Don't add analytics, tracking, or anything that conflicts with the project philosophy in the README.
+
+## Publishing note
+
+This file is copied into the build output by a plugin in `vite.config.ts` so it is also served at https://nosignups.net/AGENTS.md, and it is referenced from `public/llms.txt`. If you rename or move it, update both.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,23 @@
+# NoSignups
+
+> NoSignups (formerly FckSignups) is an open-source directory of 200+ free tools that run entirely in the browser, require no signup or account, and are open source. Live at https://nosignups.net
+
+The website is a React single-page app, so the HTML served at the root URL contains no tool data. The complete directory is available as machine-readable JSON (linked below) — prefer that over scraping the site.
+
+Categories: Productivity, Design & Graphics, Development, Writing & Docs, Privacy & Security, Utilities, Data & Analytics, Media, Education, Lists.
+
+Each tool entry has the fields: `id`, `name`, `description`, `url`, `category`, `tags`, plus optional `github`, `license`, `stars`, `featured`, and `notRecommendedReason`.
+
+## Data
+
+- [Full tool directory (JSON)](https://raw.githubusercontent.com/BraveOPotato/FckSignups/refs/heads/main/tools.json): every listed tool with description, URL, category, tags, license, and GitHub stars
+
+## Docs
+
+- [README](https://raw.githubusercontent.com/BraveOPotato/FckSignups/refs/heads/main/README.md): project overview, philosophy, tool schema, and contribution guidelines
+- [AGENTS.md](https://nosignups.net/AGENTS.md): instructions for AI coding agents working on the repository
+
+## Contributing
+
+- [Submit a tool](https://github.com/BraveOPotato/FckSignups/issues/new?template=request-to-add-a-tool.md): request to add a no-signup tool to the directory
+- [GitHub repository](https://github.com/BraveOPotato/FckSignups): source code (GPL-3.0)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,23 @@
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
+import { copyFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// AGENTS.md lives at the repo root (the standard location for coding agents),
+// so copy it into the build output to also serve it at /AGENTS.md.
+function publishAgentsMd(): Plugin {
+  return {
+    name: "publish-agents-md",
+    apply: "build",
+    closeBundle() {
+      copyFileSync(
+        resolve(__dirname, "AGENTS.md"),
+        resolve(__dirname, "dist/AGENTS.md"),
+      );
+    },
+  };
+}
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), publishAgentsMd()],
 });


### PR DESCRIPTION
## What

Makes the directory readable by LLMs and AI coding agents:

- **`public/llms.txt`** — served at `https://nosignups.net/llms.txt` following the [llmstxt.org](https://llmstxt.org) convention. Since the site is a React SPA, an LLM fetching the root URL gets an empty HTML shell; this file summarizes the project and points them at the machine-readable `tools.json` raw URL instead of scraping the site.
- **`AGENTS.md`** — repo-root instructions for AI coding agents per the [agents.md](https://agents.md) convention: commands, project layout, `tools.json` schema, and the contribution rules (no-signup requirement, <140-char descriptions, 3–5 tags).
- **`vite.config.ts`** — a small build-only plugin that copies `AGENTS.md` into `dist/` so it is also served at `https://nosignups.net/AGENTS.md` (linked from `llms.txt`).

## Why

More and more people find tools by asking an LLM. These two files let assistants like ChatGPT and Claude discover and correctly cite the NoSignups directory, and help coding agents contribute to the repo following your guidelines.

## Verification

`npm run build` passes; `dist/` contains both `llms.txt` and `AGENTS.md` after the build. No runtime code paths touched — the vite change is build-time only (`apply: "build"`), so `npm run dev` is unaffected.