### PR TITLE
Add auto-generated llms.txt + AGENTS.md, CHANGELOG.md, and bump to 1.1.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,66 @@
+# AGENTS.md
+
+Guidance for AI coding agents working on this repository.
+
+## What this project is
+
+NoSignups (formerly FckSignups) is an open-source directory of free tools that run in the browser, require no signup, and are open source. It is a React + TypeScript single-page app built with Vite, deployed at https://nosignups.net. The code is licensed GPL-3.0.
+
+## Commands
+
+```bash
+npm install        # install dependencies
+npm run dev        # start the Vite dev server
+npm run build      # type-check (tsc) and build to dist/
+npm run preview    # preview the production build
+```
+
+There is no test suite. `npm run build` is the correctness gate — it must pass (TypeScript strict compilation) before you commit.
+
+## Project layout
+
+- `tools.json` — the tool directory data (categories + tools). This is the heart of the project. In production the app fetches it from the raw GitHub URL of the `main` branch, so changes to it go live without a redeploy.
+- `src/` — the React app:
+  - `src/hooks/useTools.ts` — loads `tools.json` (dev path → prod raw URL → `src/constants/fallbackData.ts`), filtering and sorting.
+  - `src/components/` — UI components (Header, Controls, ToolGrid, ToolCard, Footer, Toast, Report).
+  - `src/hooks/useModal/` — the submit/suggest/report modal system; field definitions live in `src/constants/ModalConfigs.tsx`.
+  - `src/types/index.ts` — the `Tool`, `Category`, and `ToolsData` interfaces. Keep `tools.json` consistent with these.
+- `public/` — static files copied verbatim to the site root at build time (e.g. `llms.txt`).
+- `cloudflare-worker/` — a separate Cloudflare Worker that receives submit/suggest/report form posts and opens GitHub issues. It has its own `package.json` and is not part of the Vite build.
+- `management_tools/` — Python maintenance scripts (adding tools from issues, refreshing GitHub star counts).
+
+## Editing tools.json
+
+Each tool entry follows this schema (see also the README):
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `id` | Yes | URL-friendly unique identifier |
+| `name` | Yes | Display name |
+| `description` | Yes | One sentence, under 140 characters |
+| `url` | Yes | Direct link to the tool |
+| `category` | Yes | Must match a category `id` in the same file |
+| `tags` | No | 3–5 searchable keywords |
+| `github` | No | Source repository link |
+| `license` | No | SPDX identifier |
+| `stars` | No | GitHub star count |
+| `featured` | No | Boolean; pins to top |
+| `notRecommendedReason` | No | Why the entry is not recommended |
+
+Rules for adding a tool:
+
+- It must work **without creating an account** — this is the project's core promise.
+- It should run in the browser and be open source.
+- Keep the description under 140 characters and use 3–5 relevant tags.
+- Validate that the file is still valid JSON after editing.
+
+## Conventions
+
+- TypeScript strict mode; functional React components with hooks.
+- No CSS framework — styles live in `src/index.css`.
+- Keep dependencies minimal; this project deliberately avoids bloat.
+- Don't add analytics, tracking, or anything that conflicts with the project philosophy in the README.
+
+## Publishing note
+
+This file is copied into the build output by a plugin in `vite.config.ts` so it is also served at https://nosignups.net/AGENTS.md, and it is referenced from `public/llms.txt`. If you rename or move it, update both.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ Rules for adding a tool:
 - No CSS framework — styles live in `src/index.css`.
 - Keep dependencies minimal; this project deliberately avoids bloat.
 - Don't add analytics, tracking, or anything that conflicts with the project philosophy in the README.
+- Record notable site/tooling changes in `CHANGELOG.md` ([Keep a Changelog](https://keepachangelog.com) format) and bump `package.json` per [SemVer](https://semver.org). Routine `tools.json` edits don't need a changelog entry.
 
 ## Publishing note
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,10 +9,11 @@ NoSignups (formerly FckSignups) is an open-source directory of free tools that r
 ## Commands
 
 ```bash
-npm install        # install dependencies
-npm run dev        # start the Vite dev server
-npm run build      # type-check (tsc) and build to dist/
-npm run preview    # preview the production build
+npm install            # install dependencies
+npm run dev            # start the Vite dev server
+npm run build          # regenerate LLM docs, type-check (tsc), build to dist/
+npm run preview        # preview the production build
+npm run generate:llms  # regenerate the tool lists in llms.txt and AGENTS.md
 ```
 
 There is no test suite. `npm run build` is the correctness gate — it must pass (TypeScript strict compilation) before you commit.
@@ -28,6 +29,7 @@ There is no test suite. `npm run build` is the correctness gate — it must pass
 - `public/` — static files copied verbatim to the site root at build time (e.g. `llms.txt`).
 - `cloudflare-worker/` — a separate Cloudflare Worker that receives submit/suggest/report form posts and opens GitHub issues. It has its own `package.json` and is not part of the Vite build.
 - `management_tools/` — Python maintenance scripts (adding tools from issues, refreshing GitHub star counts).
+- `scripts/generateLlmsDocs.mjs` — regenerates the tool lists embedded in `public/llms.txt` and this file from `tools.json`; runs automatically as part of `npm run build`.
 
 ## Editing tools.json
 
@@ -53,6 +55,8 @@ Rules for adding a tool:
 - It should run in the browser and be open source.
 - Keep the description under 140 characters and use 3–5 relevant tags.
 - Validate that the file is still valid JSON after editing.
+- Check the auto-generated tool index at the bottom of this file for duplicates first.
+- After editing `tools.json`, run `npm run generate:llms` and commit the regenerated `public/llms.txt` and `AGENTS.md` together with it.
 
 ## Conventions
 
@@ -63,4 +67,250 @@ Rules for adding a tool:
 
 ## Publishing note
 
-This file is copied into the build output by a plugin in `vite.config.ts` so it is also served at https://nosignups.net/AGENTS.md, and it is referenced from `public/llms.txt`. If you rename or move it, update both.
+This file is copied into the build output by a plugin in `vite.config.ts` so it is also served at https://nosignups.net/AGENTS.md, and it is referenced from `public/llms.txt`. If you rename or move it, update both, plus `scripts/generateLlmsDocs.mjs`.
+
+## Tool index (auto-generated)
+
+<!-- BEGIN GENERATED TOOL LIST -->
+210 tools across 10 categories, generated from tools.json. Check here before adding a tool to avoid duplicates.
+
+### Productivity (`productivity`, 17 tools)
+
+- `webllm` — [WebLLM](https://webllm.mlc.ai/)
+- `grist` — [Grist](https://docs.getgrist.com)
+- `cryptpad` — [CryptPad](https://cryptpad.fr)
+- `stirling-pdf` — [Stirling-PDF](https://stirling.com/app)
+- `bentopdf` — [BentoPDF](https://www.bentopdf.com/)
+- `asciiflow` — [ASCIIFlow](https://asciiflow.com/)
+- `mirotalk-p2p` — [MiroTalk P2P](https://p2p.mirotalk.com/)
+- `flowchartfun` — [flowchart.fun](https://flowchart.fun/)
+- `ethercalc` — [EtherCalc](https://ethercalc.net/)
+- `tomodoro` — [Tomodoro](https://lazy-guy.github.io/tomodoro/)
+- `resume-nation` — [Resume Nation](https://resume-nation.github.io)
+- `dsheets` — [dSheets](https://dsheets.new/)
+- `dohabit` — [DoHabit](https://dohabit.app/)
+- `quickretro` — [QuickRetro](https://quickretro.app/)
+- `sipp-chat` — [Sipp Chat](https://chat.sipp.sh/)
+- `tailit` — [Tailit](https://tailit.xyz/)
+- `mermify` — [Mermify](https://tra-sco.github.io/mermify/)
+
+### Design & Graphics (`design`, 37 tools)
+
+- `excalidraw` — [Excalidraw](https://excalidraw.com)
+- `graphite` — [Graphite](https://editor.graphite.rs)
+- `jspaint` — [JSPaint](https://jspaint.app)
+- `tldraw` — [tldraw](https://www.tldraw.com/)
+- `piskel` — [Piskel](https://www.piskelapp.com)
+- `pixelorama` — [Pixelorama](https://orama-interactive.itch.io/pixelorama)
+- `dashboard-icons` — [Dashboard Icons](https://dashboardicons.com/)
+- `svg-edit` — [SVG-Edit](https://svgedit.netlify.app/index.html)
+- `drawio` — [draw.io](https://www.drawio.com/)
+- `blockbench` — [Blockbench](https://web.blockbench.net/)
+- `svgpatheditor` — [SvgPathEditor](https://yqnn.github.io/svg-path-editor/)
+- `makegirlsmoe` — [MakeGirlsMoe](https://make.girls.moe)
+- `terraink` — [TerraInk](https://terraink.app/)
+- `pattern-craft` — [Pattern Craft](https://patterncraft.store/)
+- `method-draw` — [Method Draw](https://editor.method.ac)
+- `godsvg` — [GodSVG](https://www.godsvg.com/editor/)
+- `thesvg` — [TheSVG](https://thesvg.org/)
+- `icon-maker` — [Icon Maker](https://ray.so/icon)
+- `pixel-craft` — [PixelCraft](https://pixelcraft.web.app)
+- `vecto3d` — [Vecto3d](https://vecto3d.app/)
+- `screenshot-studio` — [Screenshot Studio](https://www.screenshot-studio.com/)
+- `klecks` — [Klecks](https://kleki.com/)
+- `component-gallery` — [Component Gallery](https://component.gallery/)
+- `glyphr-studio` — [Glyphr Studio](https://www.glyphrstudio.com/)
+- `studio` — [Studio](https://studio.neato.fun/)
+- `phosphor-cam` — [Phosphor-Cam](https://phosphor-cam.vercel.app/)
+- `darklyart` — [Darkly.Art](https://darkly.art/)
+- `fluid` — [Fluid](https://fluid.krackeddevs.com/)
+- `toolsforimage` — [ToolsForImage](https://toolsforimage.com/)
+- `word-aligner` — [Word Aligner](https://aligner.tinygods.dev)
+- `voidmesh` — [VoidMesh](https://voidmesh.xyz/)
+- `drawshare` — [DrawShare](https://shravangoswami.com/DrawShare/)
+- `colorkit` — [ColorKit](https://colorskit.vercel.app/)
+- `shadestudio` — [ShadeStudio](https://laura.media/shade-studio/)
+- `planar` — [Planar](https://planar.masn.studio)
+- `dither` — [dither](https://dither.fuego.im/)
+- `image-to-unicodeascii-generator` — [Image to UnicodeASCII Generator](https://reactorcore.itch.io/image-to-unicodeascii-generator)
+
+### Development (`development`, 58 tools)
+
+- `drawdb` — [drawDB](https://www.drawdb.app)
+- `visual-studio-code-for-the-web` — [Visual Studio Code for the Web](https://vscode.dev/)
+- `hoppscotch` — [hoppscotch](https://hoppscotch.io/)
+- `algorithm-visualizer` — [Algorithm Visualizer](https://algorithm-visualizer.org/)
+- `json-crack` — [JSON Crack](https://jsoncrack.com/)
+- `it-tools` — [IT-Tools](https://it-tools.tech/)
+- `carbon` — [carbon](https://carbon.now.sh/)
+- `feather` — [Feather](https://feathericons.com/)
+- `simple-icons` — [Simple Icons](https://simpleicons.org/)
+- `heroicons` — [heroicons](https://heroicons.com/)
+- `lucide` — [Lucide](https://lucide.dev/)
+- `tabler-icons` — [Tabler Icons](https://tabler.io/icons)
+- `ffmpegwasm` — [ffmpeg.wasm](https://ffmpegwasm.netlify.app/playground)
+- `explainshellcom` — [explainshell.com](https://explainshell.com/)
+- `markmap` — [Markmap](https://markmap.js.org/)
+- `quickrefme` — [QuickRef.ME](https://quickref.me/)
+- `regexr` — [RegExr](https://regexr.com/)
+- `bundlephobia` — [Bundlephobia](https://bundlephobia.com/)
+- `transform` — [Transform](https://transform.tools/)
+- `remix-icons` — [Remix Icons](https://remixicon.com/)
+- `phosphor-icons` — [Phosphor Icons](https://ionic.io/ionicons)
+- `mermaid-live` — [Mermaid Live](https://mermaid.live)
+- `ast-explorer` — [AST explorer](https://astexplorer.net/)
+- `svgomg` — [SVGOMG](https://jakearchibald.github.io/svgomg/)
+- `iconoir` — [Iconoir](https://iconoir.com/)
+- `openmoji` — [OpenMoji](https://openmoji.org/library/)
+- `js-bin` — [JS Bin](https://jsbin.com)
+- `kroki` — [Kroki](https://kroki.io/#try)
+- `codegraphcontext-cgc` — [CodeGraphContext (CGC)](https://cgc.codes/explore)
+- `circuitjs1` — [CircuitJS1](https://www.falstad.com/circuit/)
+- `dart-pad` — [DartPad](https://dartpad.dev)
+- `gitfut` — [GitFut](https://gitfut.com/)
+- `online-tools` — [Online tools](https://emn178.github.io/online-tools/)
+- `rom-patcher-js` — [Rom Patcher JS](https://www.marcrobledo.com/RomPatcher.js/)
+- `kicanvas` — [KiCanvas](https://kicanvas.org/)
+- `sqlime` — [Sqlime](https://sqlime.org/)
+- `selfh-st-icons` — [selfh.st Icons](https://selfh.st/icons/)
+- `checkmygit` — [CheckMyGit](https://checkmygit.com/)
+- `delphitools` — [delphitools](https://delphi.tools/)
+- `openhero` — [Openhero](https://openhero.art/)
+- `asm-editor` — [ASM Editor](https://asm-editor.specy.app)
+- `python-tutor` — [Python Tutor](https://pythontutor.com)
+- `log-voyager` — [Log Voyager](https://www.logvoyager.cc/)
+- `niolesk` — [Niolesk](niolesk.top)
+- `gistssh` — [gists.sh](https://gists.sh/)
+- `rooc-optimization` — [ROOC Optimization](https://rooc.specy.app/)
+- `tokeko` — [Tokeko](https://tokeko.specy.app/)
+- `ffmpeg-cli-online` — [FFmpeg CLI Online](https://ffmpeg.wide.video)
+- `verisim` — [VeriSim](https://senolgulgonul.github.io/verisim/)
+- `app-store-web-search` — [App Store Web Search](https://vexelon.net/asws)
+- `codemap-ai` — [CodeMap AI](https://code-map-ai-mu.vercel.app/)
+- `csv-repair` — [CSV Repair](https://www.csv.repair/)
+- `gately` — [Gately](https://www.gately.dev/)
+- `online-maven-download-tool` — [Online Maven Download Tool](https://maven-tools.mohants.com/)
+- `scratch-tabs` — [Scratch Tabs](https://app.scratchtabs.com/)
+- `faviconapi` — [FaviconAPI](https://faviconapi.com)
+- `opencode-config-builder` — [OpenCode Config Builder](https://openconfig.mikescave.us)
+- `beziermotion` — [BezierMotion](https://tughloks.github.io/BezierMotion/)
+
+### Writing & Docs (`writing`, 17 tools)
+
+- `stackedit` — [StackEdit](https://stackedit.io)
+- `affine` — [AFFiNE](https://affine.pro/)
+- `logseq` — [Logseq](https://logseq.com/)
+- `koodo-reader` — [Koodo Reader](https://web.koodoreader.com/)
+- `dillinger` — [Dillinger](https://dillinger.io)
+- `lookscanned` — [lookscanned](https://lookscanned.io)
+- `linwood-butterfly` — [Linwood Butterfly](https://web.butterfly.linwood.dev/)
+- `universal-résumé-template` — [Universal Résumé Template](https://universalresume.app/?s=g)
+- `markdown-live-preview` — [Markdown Live Preview](https://markdownlivepreview.com)
+- `notepad-pwa` — [Notepad PWA](https://notepad.js.org)
+- `ddocs` — [dDocs](https://ddocs.new/)
+- `browserpad` — [Browserpad](https://browserpad.org)
+- `free-cv-builder` — [Free CV Builder](https://buildmyfree.cv/)
+- `easypeasycv` — [EasyPeasyCV](https://easypeasycv.com/)
+- `strong-editor` — [Strong Editor](https://strongeditor.com/)
+- `editorpilot` — [EditorPilot](https://editorpilot.com/)
+- `goatpad` — [GoatPad](https://goatpad.drexfall.com/)
+
+### Privacy & Security (`privacy`, 8 tools)
+
+- `privacy-sexy` — [privacy.sexy](https://privacy.sexy)
+- `cyberchef` — [CyberChef](https://gchq.github.io/CyberChef/)
+- `cryptii` — [Cryptii](https://cryptii.com)
+- `cryptgeon` — [Cryptgeon](https://cryptgeon.com/)
+- `image-scrubber` — [image-scrubber](https://everestpipkin.github.io/image-scrubber/)
+- `metadata-remover` — [Metadata Remover](https://ianonymous3000.github.io/metadata-remover/)
+- `protegemidni` — [ProtegeMiDNI](https://protegemidni.es)
+- `shareclean` — [ShareClean](https://omarh-creator.github.io/ShareClean/#playground)
+
+### Utilities (`utilities`, 37 tools)
+
+- `pairdrop` — [PairDrop](https://pairdrop.net/)
+- `localsend-web` — [LocalSend-Web](https://web.localsend.org/)
+- `ente-paste` — [ente Paste](https://paste.ente.com/)
+- `readest` — [Readest](https://web.readest.com/)
+- `vert` — [VERT](https://vert.sh/)
+- `convert` — [Convert To It](http://convert.to.it/)
+- `spliit` — [Spliit](https://spliit.app/)
+- `enclosed` — [Enclosed](https://enclosed.cc/)
+- `paperknife` — [PaperKnife](https://potatameister.github.io/PaperKnife/)
+- `filedrop` — [FileDrop](https://drop.lol/)
+- `qrcodeshow` — [QrCodeShow](https://qrcode.show/)
+- `qrazybox` — [QRazyBox](https://merricx.github.io/qrazybox/)
+- `e2ecp` — [e2ecp](https://e2ecp.com)
+- `brouter-web` — [BRouter-web](https://brouter.de/brouter-web/)
+- `openreader` — [OpenReader](https://openreader.richardr.dev/app)
+- `sharr` — [Sharr](https://www.sharrr.com/)
+- `cheezypizza` — [CheezyPizza](https://file.pizza/)
+- `gridfinity-layout-tool` — [Gridfinity Layout Tool](https://gridfinitylayouttool.com)
+- `giraffile` — [Giraffile](https://giraffile.pages.dev/)
+- `webtorio` — [Webtor.io](https://webtor.io/)
+- `clip-fish` — [Clip Fish](https://clip.fish/)
+- `kpaste` — [kPaste](https://kpaste.infomaniak.com/)
+- `owncardly` — [OwnCardly](https://owncardly.com/)
+- `texturinator` — [Texturinator](https://texturinator.buttermilch-dev.de/)
+- `open-razerkit` — [Open-RazerKit](https://hamzayslmn.github.io/open-razerkit/)
+- `pandoc-wasm` — [Pandoc WASM](https://pandoc.github.io/pandoc-wasm/)
+- `toolsatzero` — [ToolsAtZero](https://www.toolsatzero.com/)
+- `oscilloscope-online-v2` — [Oscilloscope Online V2](https://mumarshahbaz.github.io/Oscilloscope-Online-V2/setup.html)
+- `dropsilk` — [DropSilk](https://www.dropsilk.xyz/)
+- `daggerheart-gm-screen` — [Daggerheart GM Screen](https://jutier.github.io/Daggerheart/)
+- `jobber` — [Jobber](https://rssjobs.app/)
+- `relay` — [Relay](https://relay.rishishah.in)
+- `zkdrop` — [zkdrop](https://zkdrop.org)
+- `xipe` — [xipe](https://xi.pe/)
+- `ul0` — [Ul0](https://ul0.site)
+- `qtransfer` — [qTransfer](https://transfer-cv5.pages.dev/)
+- `enumbers-lookup` — [enumbers lookup](https://enumbers.jarvisdiscordbot.net/)
+
+### Data & Analytics (`data`, 9 tools)
+
+- `world-monitor` — [World Monitor](https://www.worldmonitor.app/)
+- `rawgraphs` — [RAWGraphs](https://app.rawgraphs.io)
+- `osiris` — [OSIRIS](https://www.osirisai.live/)
+- `mr-data-converter` — [Mr. Data Converter](https://shancarter.github.io/mr-data-converter/)
+- `datasette-lite` — [Datasette Lite](https://lite.datasette.io)
+- `sqlchef` — [SQLChef](https://jonathanwalker.github.io/SQLChef/)
+- `schema3d` — [Schema3D](https://schema3d.com/)
+- `satvisor` — [Satvisor](https://satvisor.com/)
+- `grade-boundaries` — [Grade Boundaries](https://gradeboundaries.com)
+
+### Media (`media`, 19 tools)
+
+- `opencut` — [OpenCut](https://opencut.app)
+- `cobalt` — [Cobalt](https://cobalt.tools/)
+- `squoosh` — [Squoosh](https://squoosh.app/)
+- `subtitleedit` — [SubtitleEdit](https://www.nikse.dk/subtitleedit/online)
+- `openreel` — [OpenReel](https://openreel.video/)
+- `audiomass` — [AudioMass](https://audiomass.co/)
+- `image-max-url` — [Image Max URL](https://qsniyg.github.io/maxurl/)
+- `freecut` — [FreeCut](https://freecut.net)
+- `openvid` — [Openvid](https://openvid.dev/en)
+- `omniclip` — [OmniClip](https://omniclip.app/)
+- `mini-photoeditor` — [MiNi PhotoEditor](https://mini2-photo-editor.netlify.app/)
+- `wavacity` — [Wavacity](https://wavacity.com/)
+- `compress` — [Compress](https://videocompress.prolab.sh/)
+- `drumhaus` — [Drumhaus](https://drumha.us/)
+- `composeyogi` — [ComposeYogi](https://composeyogi.com/)
+- `midee` — [Midee](https://midee.app/)
+- `greendolphin` — [GreenDolphin](https://greendolph.in)
+- `clearcanvas-ai` — [ClearCanvas AI](https://clearcanvasai.vercel.app/)
+- `s-2-v` — [s-2-v](https://s-2-v.pages.dev/)
+
+### Education (`education`, 5 tools)
+
+- `roadmapssh` — [Roadmaps.sh](https://roadmap.sh/)
+- `full-stack-open` — [Full Stack open](https://fullstackopen.com/en/)
+- `agora-cosmica` — [Agora Cosmica](https://agoracosmica.org)
+- `quizbun` — [Quizbun](https://a-dev.github.io/quizbun/)
+- `the-missing-manual` — [The Missing Manual](https://themissingmanual.dev)
+
+### Lists (`lists`, 3 tools)
+
+- `free-fordev` — [free-for.dev](https://free-for.dev/#/)
+- `osint-framework` — [OSINT Framework](https://osintframework.com/)
+- `freemediaheckyeah` — [freemediaheckyeah](https://fmhy.net/)
+<!-- END GENERATED TOOL LIST -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Tool additions and removals happen continuously in `tools.json` and go live
+without a release; this changelog tracks changes to the site and tooling itself.
+
+## [Unreleased]
+
+## [1.1.0] - 2026-07-14
+
+### Added
+
+- `public/llms.txt`, served at `https://nosignups.net/llms.txt` per the
+  [llmstxt.org](https://llmstxt.org) convention, embedding the complete tool
+  directory so LLMs can read it in one fetch.
+- `AGENTS.md`, repo-root instructions for AI coding agents per the
+  [agents.md](https://agents.md) convention, with an auto-generated tool index
+  for duplicate checking. Also served at `https://nosignups.net/AGENTS.md`.
+- `scripts/generateLlmsDocs.mjs`, a zero-dependency script that regenerates
+  the tool lists in both files from `tools.json` (`npm run generate:llms`).
+- This changelog.
+
+### Changed
+
+- `npm run build` now regenerates the LLM docs from `tools.json` before
+  compiling, so the published copies always match the latest data.
+
+## [1.0.0] - 2026-05-07
+
+### Added
+
+- Initial release: the FckSignups (now NoSignups) directory — a React +
+  TypeScript + Vite single-page app listing open-source, in-browser,
+  no-signup tools.
+- `tools.json` as the single source of truth for categories and tools,
+  fetched at runtime from the `main` branch.
+- Cloudflare Worker (`cloudflare-worker/`) handling submit, suggest, and
+  report forms by opening GitHub issues.
+- Python maintenance scripts (`management_tools/`) for adding tools from
+  issues and refreshing GitHub star counts.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcksignups",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
-    "preview": "vite preview"
+    "build": "npm run generate:llms && tsc && vite build",
+    "preview": "vite preview",
+    "generate:llms": "node scripts/generateLlmsDocs.mjs"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,23 @@
+# NoSignups
+
+> NoSignups (formerly FckSignups) is an open-source directory of 200+ free tools that run entirely in the browser, require no signup or account, and are open source. Live at https://nosignups.net
+
+The website is a React single-page app, so the HTML served at the root URL contains no tool data. The complete directory is available as machine-readable JSON (linked below) — prefer that over scraping the site.
+
+Categories: Productivity, Design & Graphics, Development, Writing & Docs, Privacy & Security, Utilities, Data & Analytics, Media, Education, Lists.
+
+Each tool entry has the fields: `id`, `name`, `description`, `url`, `category`, `tags`, plus optional `github`, `license`, `stars`, `featured`, and `notRecommendedReason`.
+
+## Data
+
+- [Full tool directory (JSON)](https://raw.githubusercontent.com/BraveOPotato/FckSignups/refs/heads/main/tools.json): every listed tool with description, URL, category, tags, license, and GitHub stars
+
+## Docs
+
+- [README](https://raw.githubusercontent.com/BraveOPotato/FckSignups/refs/heads/main/README.md): project overview, philosophy, tool schema, and contribution guidelines
+- [AGENTS.md](https://nosignups.net/AGENTS.md): instructions for AI coding agents working on the repository
+
+## Contributing
+
+- [Submit a tool](https://github.com/BraveOPotato/FckSignups/issues/new?template=request-to-add-a-tool.md): request to add a no-signup tool to the directory
+- [GitHub repository](https://github.com/BraveOPotato/FckSignups): source code (GPL-3.0)

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -2,15 +2,11 @@
 
 > NoSignups (formerly FckSignups) is an open-source directory of 200+ free tools that run entirely in the browser, require no signup or account, and are open source. Live at https://nosignups.net
 
-The website is a React single-page app, so the HTML served at the root URL contains no tool data. The complete directory is available as machine-readable JSON (linked below) — prefer that over scraping the site.
-
-Categories: Productivity, Design & Graphics, Development, Writing & Docs, Privacy & Security, Utilities, Data & Analytics, Media, Education, Lists.
-
-Each tool entry has the fields: `id`, `name`, `description`, `url`, `category`, `tags`, plus optional `github`, `license`, `stars`, `featured`, and `notRecommendedReason`.
+The website is a React single-page app, so the HTML served at the root URL contains no tool data. The complete, up-to-date directory is embedded below (regenerated from tools.json on every build), and is also available as machine-readable JSON.
 
 ## Data
 
-- [Full tool directory (JSON)](https://raw.githubusercontent.com/BraveOPotato/FckSignups/refs/heads/main/tools.json): every listed tool with description, URL, category, tags, license, and GitHub stars
+- [Full tool directory (JSON)](https://raw.githubusercontent.com/BraveOPotato/FckSignups/refs/heads/main/tools.json): every listed tool with description, URL, category, tags, license, and GitHub stars — fields: `id`, `name`, `description`, `url`, `category`, `tags`, plus optional `github`, `license`, `stars`, `featured`, and `notRecommendedReason`
 
 ## Docs
 
@@ -21,3 +17,267 @@ Each tool entry has the fields: `id`, `name`, `description`, `url`, `category`, 
 
 - [Submit a tool](https://github.com/BraveOPotato/FckSignups/issues/new?template=request-to-add-a-tool.md): request to add a no-signup tool to the directory
 - [GitHub repository](https://github.com/BraveOPotato/FckSignups): source code (GPL-3.0)
+
+<!-- BEGIN GENERATED TOOL LIST -->
+The full directory (210 tools, 10 categories) follows. This block is auto-generated from tools.json at build time.
+
+## Productivity
+
+Get things done without creating accounts
+
+- [WebLLM](https://webllm.mlc.ai/): High-performance In-browser LLM Inference Engine ([source](https://github.com/mlc-ai/web-llm), Apache-2.0)
+- [Grist](https://docs.getgrist.com): Modern relational spreadsheet. It combines the flexibility of a spreadsheet with the robustness of a database ([source](https://github.com/gristlabs/grist-core), Apache-2.0)
+- [CryptPad](https://cryptpad.fr): Collaborative office suite, end-to-end encrypted and open-source. ([source](https://github.com/cryptpad/cryptpad), AGPL-3.0)
+- [Stirling-PDF](https://stirling.com/app): #1 PDF Application on GitHub that lets you edit PDFs on any device anywhere ([source](https://github.com/Stirling-Tools/Stirling-PDF), MIT) — ⚠️ not recommended: Skippable-signup
+- [BentoPDF](https://www.bentopdf.com/): Powerful, privacy-first, client-side PDF toolkit that is self hostable and allows you to manipulate, edit, merge, and process PDF files ([source](https://github.com/alam00000/bentopdf/), AGPL-3.0)
+- [ASCIIFlow](https://asciiflow.com/): An application for drawing ASCII diagrams ([source](https://github.com/lewish/asciiflow), MIT)
+- [MiroTalk P2P](https://p2p.mirotalk.com/): WebRTC video conferencing platform built on peer-to-peer (P2P) architecture for fast, secure real-time communication with end-to-end privacy ([source](https://github.com/miroslavpejic85/mirotalk), AGPL-3.0)
+- [flowchart.fun](https://flowchart.fun/): Easily generate flowcharts and diagrams from text ([source](https://github.com/tone-row/flowchart-fun), MIT)
+- [EtherCalc](https://ethercalc.net/): Spreadsheet for real-time collaborative editing ([source](https://github.com/audreyt/ethercalc), CPAL-1.0)
+- [Tomodoro](https://lazy-guy.github.io/tomodoro/): A pomodoro web app with PIP mode, white noise generation, tasks and more! ([source](https://github.com/lazy-guy/tomodoro), MIT)
+- [Resume Nation](https://resume-nation.github.io): Progressive resume builder which works offline ([source](https://github.com/resume-nation/resume-nation.github.io), MIT)
+- [dSheets](https://dsheets.new/): dsheets.new is alternative to google sheets & excel. ([source](https://github.com/fileverse/fileverse-dsheet), AGPL-3.0)
+- [DoHabit](https://dohabit.app/): Lightweight, local-first habit tracker designed to respect your privacy ([source](https://github.com/iNikAnn/DoHabit), AGPL-3.0)
+- [QuickRetro](https://quickretro.app/): Real-time app for conducting a remote sprint retrospective meeting ([source](https://github.com/vijeeshr/quickretro), AGPL-3.0)
+- [Sipp Chat](https://chat.sipp.sh/): AI inference, packed simply. A blazing-fast, zero-dependency WebGPU runtime to run GGUF models directly in the browser ([source](https://github.com/noumena-labs/Sipp), Apache-2.0)
+- [Tailit](https://tailit.xyz/): An interactive resume builder with templates. Paste a job link and AI rewrites your resume to match ([source](https://github.com/sardorml/tailit), MIT)
+- [Mermify](https://tra-sco.github.io/mermify/): Bi-directional visual editor for Mermaid.js flowcharts ([source](https://github.com/tra-sco/mermify), MIT)
+
+## Design & Graphics
+
+Create visuals right in your browser
+
+- [Excalidraw](https://excalidraw.com): Virtual whiteboard for sketching hand-drawn like diagrams ([source](https://github.com/excalidraw/excalidraw), MIT)
+- [Graphite](https://editor.graphite.rs): Community-built comprehensive 2D content creation appplication for graphic design, digital art, and interactive real-time motion graphics powered by a node-based procedural graphics engine ([source](https://github.com/GraphiteEditor/Graphite), Apache-2.0)
+- [JSPaint](https://jspaint.app): 🎨 Classic MS Paint, ＲＥＶＩＶＥＤ + ✨Extras ([source](https://github.com/1j01/jspaint), MIT)
+- [tldraw](https://www.tldraw.com/): A simple drawing/whiteboarding tool ([source](https://github.com/tldraw/tldraw), NC)
+- [Piskel](https://www.piskelapp.com): Easy-to-use sprite editor. It can be used to create game sprites, animations, and pixel-art ([source](https://github.com/piskelapp/piskel), Apache-2.0)
+- [Pixelorama](https://orama-interactive.itch.io/pixelorama): Create pixel art in your browser ([source](https://github.com/Orama-Interactive/Pixelorama), MIT)
+- [Dashboard Icons](https://dashboardicons.com/): A collection of over 1800 curated icons for services, applications and tools, designed specifically for dashboards and app directories ([source](https://github.com/homarr-labs/dashboard-icons), Apache-2.0)
+- [SVG-Edit](https://svgedit.netlify.app/index.html): Powerful SVG-Editor for your browser ([source](https://github.com/SVG-Edit/svgedit), MIT)
+- [draw.io](https://www.drawio.com/): A configurable browser-based diagramming and whiteboarding tool for flowcharts, UML, network diagrams, ER diagrams, BPMN, and more. ([source](https://github.com/jgraph/drawio), Apache-2.0)
+- [Blockbench](https://web.blockbench.net/): A low poly 3D model editor ([source](https://github.com/JannisX11/blockbench), GPL-3.0)
+- [SvgPathEditor](https://yqnn.github.io/svg-path-editor/): Online editor to create and manipulate SVG paths ([source](https://github.com/Yqnn/svg-path-editor), Apache-2.0)
+- [MakeGirlsMoe](https://make.girls.moe): Create Anime Characters ([source](https://github.com/makegirlsmoe/makegirlsmoe_web), CC BY-NC 2.0)
+- [TerraInk](https://terraink.app/): Cartographic poster engine ([source](https://github.com/yousifamanuel/terraink), MIT)
+- [Pattern Craft](https://patterncraft.store/): Professional-grade background patterns and gradients for your websites and apps ([source](https://github.com/megh-bari/pattern-craft), MIT)
+- [Method Draw](https://editor.method.ac): Simple and easy-to-use SVG editor experience ([source](https://github.com/methodofaction/Method-Draw), MIT)
+- [GodSVG](https://www.godsvg.com/editor/): Structured SVG editor ([source](https://github.com/MewPurPur/GodSVG), MIT)
+- [TheSVG](https://thesvg.org/): 6,100+ SVG icons. Brands, AWS, Azure, GCP, and more. Search, copy, ship. ([source](https://github.com/glincker/thesvg), MIT)
+- [Icon Maker](https://ray.so/icon): Tool that lets you quickly generate clean, professional app icons using customizable shapes, gradients, and glyphs ([source](https://github.com/raycast/ray-so), MIT)
+- [PixelCraft](https://pixelcraft.web.app): A pixel Art & Animation Creation Tool Built using HTML5 Canvas ([source](https://github.com/rgab1508/PixelCraft), MIT)
+- [Vecto3d](https://vecto3d.app/): A super simple tool to convert your SVG's to 3D models ([source](https://github.com/lakshaybhushan/vecto3d), MIT)
+- [Screenshot Studio](https://www.screenshot-studio.com/): A free, browser-based screenshot editor. Beautiful backgrounds, device frames, 3D effects, animations, and video export. No signup, no watermarks. ([source](https://github.com/KartikLabhshetwar/screenshot-studio), Apache-2.0)
+- [Klecks](https://kleki.com/): Modern and feature-rich painting app for the web ([source](https://github.com/bitbof/klecks), MIT)
+- [Component Gallery](https://component.gallery/): The Component Gallery is a collection of components from the best Design Systems. ([source](https://github.com/inbn/component-gallery), ?)
+- [Glyphr Studio](https://www.glyphrstudio.com/): Font editor, made for hobbyists and typeface design beginners ([source](https://github.com/glyphr-studio/Glyphr-Studio-2), ?)
+- [Studio](https://studio.neato.fun/): A suite of random, mostly weird, generative art tools! ([source](https://github.com/Shpigford/studio), MIT)
+- [Phosphor-Cam](https://phosphor-cam.vercel.app/): Real-time ASCII art camera that transforms your webcam feed into glowing terminal aesthetics. Built with React + Canvas API ([source](https://github.com/pshycodr/phosphor-cam), MIT)
+- [Darkly.Art](https://darkly.art/): Entropic Editor for Artists ([source](https://github.com/darkly-art/darkly), AGPL-3.0)
+- [Fluid](https://fluid.krackeddevs.com/): Dependency-free WebGL studio for generative backgrounds and live embeds ([source](https://github.com/enonforetsam/fluid), MIT)
+- [ToolsForImage](https://toolsforimage.com/): web application that provides a suite of image processing tools ([source](https://github.com/mlbrothers/ToolsForImage-OSS), MIT)
+- [Word Aligner](https://aligner.tinygods.dev): Link words across a translation, then export the diagram. ([source](https://github.com/tinygodsdev/bitext-word-alignment), MIT)
+- [VoidMesh](https://voidmesh.xyz/): Local image and video filters with shaders, on an infinite canvas ([source](https://github.com/ogdakke/voidmesh), MIT)
+- [DrawShare](https://shravangoswami.com/DrawShare/): collaborative whiteboard for drawing and note-taking ([source](https://github.com/shravanngoswamii/DrawShare), MIT)
+- [ColorKit](https://colorskit.vercel.app/): feature-rich color picker and analysis tool ([source](https://github.com/codewithdhruba01/ColorPicker), MIT)
+- [ShadeStudio](https://laura.media/shade-studio/): Create a full color palette from a base color and export it to CSS, Tailwind and SVG ([source](https://github.com/LauraWebdev/shade-studio), MIT)
+- [Planar](https://planar.masn.studio): A client-side web utility to scale, crop, and tile images onto sheets of paper for printing at exact real-world dimensions. ([source](https://github.com/Mason363/Planar), MIT)
+- [dither](https://dither.fuego.im/): Pixel-perfect dithering utility. Drop an image, dial in the settings, ship a dither ([source](https://github.com/fuegocoding/dither), ?)
+- [Image to UnicodeASCII Generator](https://reactorcore.itch.io/image-to-unicodeascii-generator): Easily transform any image into ASCII/Unicode art ([source](https://github.com/ReactorcoreGames/Image-to-UnicodeASCII-Generator/tree/main), ?)
+
+## Development
+
+Code, query, and build in the browser
+
+- [drawDB](https://www.drawdb.app): Free, simple, and intuitive online database diagram editor and SQL generator ([source](https://github.com/drawdb-io/drawdb), AGPL-3.0)
+- [Visual Studio Code for the Web](https://vscode.dev/): provides a free, zero-install Microsoft Visual Studio Code experience running entirely in your browser, allowing you to quickly and safely browse source code repositories and make lightweight code changes ([source](https://github.com/microsoft/vscode), MIT)
+- [hoppscotch](https://hoppscotch.io/): Open-Source API Development Ecosystem. Alternative to Postman, Insomnia ([source](https://github.com/hoppscotch/hoppscotch), MIT)
+- [Algorithm Visualizer](https://algorithm-visualizer.org/): An interactive online platform for visualizing algorithms from code and learning algorithm behavior through animations. ([source](https://github.com/algorithm-visualizer/algorithm-visualizer), MIT)
+- [JSON Crack](https://jsoncrack.com/): visualization application that transforms various data formats, such as JSON, YAML, XML and CSV into interactive graphs ([source](https://github.com/AykutSarac/jsoncrack.com), Apache-2.0)
+- [IT-Tools](https://it-tools.tech/): Collection of handy online tools for developers, with great UX ([source](https://github.com/corentinth/it-tools), GPL-3.0)
+- [carbon](https://carbon.now.sh/): Create and share beautiful images of your source code ([source](https://github.com/carbon-app/carbon), MIT)
+- [Feather](https://feathericons.com/): Simply beautiful open-source icons ([source](https://github.com/feathericons/feather), MIT)
+- [Simple Icons](https://simpleicons.org/): Free SVG icons for popular brands. 3000+ icons, public domain, no signup. ([source](https://github.com/simple-icons/simple-icons), CC0-1.0)
+- [heroicons](https://heroicons.com/): A set of free MIT-licensed high-quality SVG icons for UI development. ([source](https://github.com/tailwindlabs/heroicons), MIT)
+- [Lucide](https://lucide.dev/): Beautiful & consistent icon toolkit made by the community ([source](https://github.com/lucide-icons/lucide), ISC)
+- [Tabler Icons](https://tabler.io/icons): A set of over 6000 free MIT-licensed high-quality SVG icons for you to use in your web projects. ([source](https://github.com/tabler/tabler-icons), MIT)
+- [ffmpeg.wasm](https://ffmpegwasm.netlify.app/playground): FFmpeg for browser, powered by WebAssembly ([source](https://github.com/ffmpegwasm/ffmpeg.wasm), MIT)
+- [explainshell.com](https://explainshell.com/): Match command-line arguments to their help text ([source](https://github.com/idank/explainshell), GPL-3.0)
+- [Markmap](https://markmap.js.org/): Creates interactive mind maps from Markdown with a live editor and visualization ([source](https://github.com/markmap/markmap), MIT)
+- [QuickRef.ME](https://quickref.me/): Share quick reference cheat sheet for developers ([source](https://github.com/Fechin/reference), GPL-3.0)
+- [RegExr](https://regexr.com/): HTML/JS based tool for creating, testing, and learning about Regular Expressions ([source](https://github.com/gskinner/regexr/), GPL-3.0)
+- [Bundlephobia](https://bundlephobia.com/): Find out the cost of adding a new frontend dependency to your project ([source](https://github.com/pastelsky/bundlephobia), MIT)
+- [Transform](https://transform.tools/): A polyglot web converter ([source](https://github.com/ritz078/transform), MIT)
+- [Remix Icons](https://remixicon.com/): Open source neutral style icon system ([source](https://github.com/Remix-Design/RemixIcon), RIL-1.0)
+- [Phosphor Icons](https://ionic.io/ionicons): The homepage of Phosphor Icons, a flexible icon family for everyone ([source](https://github.com/phosphor-icons/homepage/tree/master), MIT)
+- [Mermaid Live](https://mermaid.live): Edit, preview and share mermaid charts/diagrams. New implementation of the live editor. ([source](https://github.com/mermaid-js/mermaid-live-editor), MIT)
+- [AST explorer](https://astexplorer.net/): A web tool to explore the ASTs generated by various parsers. ([source](https://github.com/fkling/astexplorer), MIT)
+- [SVGOMG](https://jakearchibald.github.io/svgomg/): Shrink SVG sizes dramatically ([source](https://github.com/jakearchibald/svgomg), MIT)
+- [Iconoir](https://iconoir.com/): An open source icons library with 1600+ icons, supporting React, React Native, Flutter, Vue, Figma, and Framer. ([source](https://github.com/iconoir-icons/iconoir), MIT)
+- [OpenMoji](https://openmoji.org/library/): Open source emojis for designers, developers and everyone else! ([source](https://github.com/hfg-gmuend/openmoji), CC-BY-SA-4.0)
+- [JS Bin](https://jsbin.com): Collaborative JavaScript Debugging App ([source](https://github.com/jsbin/jsbin), MIT)
+- [Kroki](https://kroki.io/#try): diagram rendering service that generates diagrams from text using tools like Mermaid, PlantUML, Graphviz, and more ([source](https://github.com/yuzutech/kroki), MIT)
+- [CodeGraphContext (CGC)](https://cgc.codes/explore): An MCP server plus a CLI tool that indexes local code into a graph database to provide context to AI assistants ([source](https://github.com/CodeGraphContext/CodeGraphContext), MIT)
+- [CircuitJS1](https://www.falstad.com/circuit/): A browser-based electronic circuit simulator with animated schematics, example circuits, and editable components. ([source](https://github.com/pfalstad/circuitjs1), GPL-2.0)
+- [DartPad](https://dartpad.dev): An online Dart editor with support for console, web, and Flutter apps. ([source](https://github.com/dart-lang/dart-pad), BSD-3-Clause)
+- [GitFut](https://gitfut.com/): Your GitHub, rated out of 99 ⚽ ([source](https://github.com/younesfdj/gitfut), MIT)
+- [Online tools](https://emn178.github.io/online-tools/): Online tools provides md2, md5, sha1, sha2, sha512, bas64, html encode / decode functions ([source](https://github.com/emn178/online-tools), ?)
+- [Rom Patcher JS](https://www.marcrobledo.com/RomPatcher.js/): A ROM patcher made in Javascript ([source](https://github.com/marcrobledo/RomPatcher.js/), MIT)
+- [KiCanvas](https://kicanvas.org/): An interactive browser-based viewer for KiCad schematics and PCB boards. ([source](https://github.com/theacodes/kicanvas), MIT)
+- [Sqlime](https://sqlime.org/): Online SQLite playground ([source](https://github.com/nalgeon/sqlime), MIT)
+- [selfh.st Icons](https://selfh.st/icons/): Dashboard Icons provided by selfh.st ([source](https://github.com/selfhst/icons), CC-BY-4.0)
+- [CheckMyGit](https://checkmygit.com/): Transform any GitHub profile into a stunning portfolio in seconds. ([source](https://github.com/whoisyurii/checkmygit), MIT)
+- [delphitools](https://delphi.tools/): A collection of small, low stakes and low effort tools ([source](https://github.com/1612elphi/delphitools), MIT)
+- [Openhero](https://openhero.art/): collection of cinematic video hero sections Browse, preview, copy & download production-ready backgrounds - instantly ([source](https://github.com/CristianOlivera1/openhero), MIT)
+- [ASM Editor](https://asm-editor.specy.app): A web editor to write, run and learn assembly code (X86, MIPS, RISC-V, M68K) ([source](https://github.com/Specy/asm-editor), AGPL-3.0)
+- [Python Tutor](https://pythontutor.com): Visualize code execution step-by-step to better understand programming concepts and debugging. ([source](https://github.com/pathrise-eng/pathrise-python-tutor), GPL-3.0)
+- [Log Voyager](https://www.logvoyager.cc/): Analyze huge log files (10GB+). Features JSON prettifier, regex filtering, and bookmarks. ([source](https://github.com/hsr88/log-voyager), MIT)
+- [Niolesk](niolesk.top): Edit diagrams from textual descriptions! ([source](https://github.com/webgiss/niolesk/), MIT)
+- [gists.sh](https://gists.sh/): GitHub Gists are the fastest way to share code, notes, and snippets. But they look terrible. This fixes that. ([source](https://github.com/linuz90/gists.sh), ?)
+- [ROOC Optimization](https://rooc.specy.app/): A web platform for modelling and solving linear optimization problems ([source](https://github.com/Specy/rooc), MPL-2.0)
+- [Tokeko](https://tokeko.specy.app/): An online creation tool for LALR and LR(1) parsers to learn how language theory works ([source](https://github.com/Specy/tokeko), ?)
+- [FFmpeg CLI Online](https://ffmpeg.wide.video): Run ffmpeg directly in your browser with a terminal-like interface. ([source](https://github.com/wide-video/ffmpeg-wasm), GPL-3.0)
+- [VeriSim](https://senolgulgonul.github.io/verisim/): Verilog simulator built by compiling Icarus Verilog to WebAssembly. No server, no install: edit, compile, simulate, view waveforms, and synthesize to a gate-level or RTL schematic ([source](https://github.com/senolgulgonul/verisim), GPL-2.0)
+- [App Store Web Search](https://vexelon.net/asws): A web app that enables you to search the Apple App Store in your browser and view app meta-data. ([source](https://github.com/petarov/appstore-web-search), MIT)
+- [CodeMap AI](https://code-map-ai-mu.vercel.app/): helps developers, especially beginners in open source, understand large repositories faster without getting lost trying to figure out where to start ([source](https://github.com/Ayansh0209/CodeMap-Ai), MIT)
+- [CSV Repair](https://www.csv.repair/): A free, browser-based tool for analyzing, querying, and repairing broken or oversized CSV files ([source](https://github.com/hsr88/csv-repair), ?)
+- [Gately](https://www.gately.dev/): Simple and modern web-based logic gate simulator ([source](https://github.com/jakmaz/gately), MIT)
+- [Online Maven Download Tool](https://maven-tools.mohants.com/): Download Maven JAR dependencies and transitive dependencies as ZIP ([source](https://github.com/pmg1991/maven-tools), MIT)
+- [Scratch Tabs](https://app.scratchtabs.com/): local-first developer workspace for exploring, transforming, and validating text/data formats ([source](https://github.com/spectra-g/scratch-tabs), MIT)
+- [FaviconAPI](https://faviconapi.com): Get the highest resolution favicon for any domain or look up a service icon by name. ([source](https://github.com/R0GGER/favicon-api/), ?)
+- [OpenCode Config Builder](https://openconfig.mikescave.us): Configuration builder/editor for opencode. ([source](https://github.com/mikecase/opencode-config-builder), ?)
+- [BezierMotion](https://tughloks.github.io/BezierMotion/): A visual cubic-bezier curve editor for crafting custom CSS easing functions ([source](https://github.com/TughlokS/BezierMotion), ?)
+
+## Writing & Docs
+
+Write, edit, and format text
+
+- [StackEdit](https://stackedit.io): Full-featured markdown editor ([source](https://github.com/benweet/stackedit), Apache-2.0)
+- [AFFiNE](https://affine.pro/): Next-gen knowledge base that brings planning, sorting and creating all together ([source](https://github.com/toeverything/AFFiNE), MIT)
+- [Logseq](https://logseq.com/): A privacy-first, open-source platform for knowledge management and collaboration ([source](https://github.com/logseq/logseq), AGPL-3.0)
+- [Koodo Reader](https://web.koodoreader.com/): A modern ebook manager and reader ([source](https://github.com/koodo-reader/koodo-reader), AGPL-3.0)
+- [Dillinger](https://dillinger.io): "The last Markdown editor, ever." ([source](https://github.com/joemccann/dillinger), MIT)
+- [lookscanned](https://lookscanned.io): Turn PDFs and documents into realistic scanned copies, add watermarks, stamps and metadata in a few clicks, with all processing done locally for maximum privacy. ([source](https://github.com/lookscanned/lookscanned.io), MIT)
+- [Linwood Butterfly](https://web.butterfly.linwood.dev/): Powerful, minimalistic, cross-platform, opensource note-taking app ([source](https://github.com/LinwoodDev/Butterfly), AGPL-3.0)
+- [Universal Résumé Template](https://universalresume.app/?s=g): Minimal and formal résumé (CV) website template for print, mobile, and desktop ([source](https://github.com/WebPraktikos/universal-resume), CC BY-NC-SA 1.0)
+- [Markdown Live Preview](https://markdownlivepreview.com): Markdown editor with live preview ([source](https://github.com/tanabe/markdown-live-preview), MIT)
+- [Notepad PWA](https://notepad.js.org): 📒 An offline capable Notepad PWA ([source](https://github.com/amitmerchant1990/notepad), MIT)
+- [dDocs](https://ddocs.new/): A privacy-first, end-to-end encrypted alternative to Google Docs for rich document editing. ([source](https://github.com/fileverse/fileverse-ddoc), AGPL-3.0)
+- [Browserpad](https://browserpad.org): Plain text editor in the browser. ([source](https://github.com/browserpad/browserpad), ISC)
+- [Free CV Builder](https://buildmyfree.cv/): Build a professional CV in a few minutes and download it as a PDF ([source](https://github.com/themidnightgospel/free-cv-builder), MIT)
+- [EasyPeasyCV](https://easypeasycv.com/): resume builder designed for professionals who value privacy, flexibility, and control over their data ([source](https://github.com/goncalojbsousa/EasyPeasyCV), MIT)
+- [Strong Editor](https://strongeditor.com/): Text editor that highlights poor wording in real-time - and makes you write better ([source](https://github.com/Great-Software-Company/strongeditor), GPL-3.0)
+- [EditorPilot](https://editorpilot.com/): AI writing assistant that lives entirely in your browser ([source](https://github.com/tuton012/editorpilot), ?)
+- [GoatPad](https://goatpad.drexfall.com/): A notepad for the web written in Flutter ([source](https://github.com/drexfall/goatpad), CC BY-NC-SA 4.0)
+
+## Privacy & Security
+
+Protect your data without trusting servers
+
+- [privacy.sexy](https://privacy.sexy): A tool to enforce privacy & security best-practices on Windows, macOS and Linux, because privacy is sexy ([source](https://github.com/undergroundwires/privacy.sexy), GPL-3.0)
+- [CyberChef](https://gchq.github.io/CyberChef/): A browser-based “cyber” workbench for encoding, decoding, encryption, compression, hashing, parsing, and data analysis recipes. ([source](https://github.com/gchq/CyberChef), Apache-2.0)
+- [Cryptii](https://cryptii.com): App for modular conversion, encoding, and encryption ([source](https://github.com/cryptii/cryptii), MIT)
+- [Cryptgeon](https://cryptgeon.com/): Send fully encrypted secure notes or files with custom expiration ([source](https://github.com/cupcakearmy/cryptgeon), MIT)
+- [image-scrubber](https://everestpipkin.github.io/image-scrubber/): A tool for anonymizing photographs taken at protests ([source](https://github.com/everestpipkin/image-scrubber), MIT)
+- [Metadata Remover](https://ianonymous3000.github.io/metadata-remover/): Removes metadata from supported formats in-browser using WASM ([source](https://github.com/iAnonymous3000/metadata-remover), MIT)
+- [ProtegeMiDNI](https://protegemidni.es): Redact the non essential info from the spanish National Identification Document ([source](https://github.com/AlfonsoML/proteccionDNI/), GPL-3.0)
+- [ShareClean](https://omarh-creator.github.io/ShareClean/#playground): A tool for sanitizing logs, stack traces, config snippets, and terminal output before you paste them into GitHub issues, support tickets, Slack, or AI chats. ([source](https://github.com/OmarH-creator/ShareClean), MIT)
+
+## Utilities
+
+Handy one-off tools for everyday tasks
+
+- [PairDrop](https://pairdrop.net/): Transfer Files Cross-Platform. No Setup, No Signup. ([source](https://github.com/schlagmichdoch/pairdrop), GPL-3.0)
+- [LocalSend-Web](https://web.localsend.org/): An open-source cross-platform alternative to AirDrop, but works in LAN only ([source](https://github.com/localsend/web), Apache-2.0)
+- [ente Paste](https://paste.ente.com/): Share text between devices securely with QR code or URL ([source](https://github.com/ente-io/ente), AGPL-3.0)
+- [Readest](https://web.readest.com/): Ebook reader designed for immersive and deep reading experiences ([source](https://github.com/readest/readest), AGPL-3.0)
+- [VERT](https://vert.sh/): File-converter fully in-browser ([source](https://github.com/VERT-sh/VERT), AGPL-3.0)
+- [Convert To It](http://convert.to.it/): Truly universal online file converter ([source](https://github.com/p2r3/convert), GPL-2.0)
+- [Spliit](https://spliit.app/): Share expenses with your friends and family ([source](https://github.com/spliit-app/spliit), MIT)
+- [Enclosed](https://enclosed.cc/): Minimalistic web application designed for sending end-to-end encrypted notes and files ([source](https://github.com/CorentinTh/enclosed), Apache-2.0)
+- [PaperKnife](https://potatameister.github.io/PaperKnife/): Merge, split, compress, and edit PDFs 100% locally on your device ([source](https://github.com/potatameister/PaperKnife), AGPL-3.0)
+- [FileDrop](https://drop.lol/): End-to-end encrypted peer-to-peer file transfer and chat in the ([source](https://github.com/mat-sz/filedrop), BSD-3-Clause-Clear)
+- [QrCodeShow](https://qrcode.show/): Generate QR code easily ([source](https://github.com/sayanarijit/qrcode.show), AGPL-3.0)
+- [QRazyBox](https://merricx.github.io/qrazybox/): web-based application (a toolkit), that used to analyzing and recovering damaged QR Code ([source](https://github.com/Merricx/qrazybox), MIT)
+- [e2ecp](https://e2ecp.com): Transfer files between machines through the web, through a CLI, or both fully end-to-end encrypted. Made by the dev of croc file transfer ([source](https://github.com/schollz/e2ecp), MIT)
+- [BRouter-web](https://brouter.de/brouter-web/): A web client for the BRouter routing engine, providing OpenStreetMap-based route planning with profile customization and route export. ([source](https://github.com/nrenner/brouter-web), MIT)
+- [OpenReader](https://openreader.richardr.dev/app): Text-to-speech document reader built with Next.js for EPUB, PDF, TXT, MD, and DOCX with multilingual, synchronized read-along playback ([source](https://github.com/richardr1126/openreader), MIT)
+- [Sharr](https://www.sharrr.com/): End-to-end encrypted file transfer ([source](https://github.com/stophecom/sharrr-svelte), MIT)
+- [CheezyPizza](https://file.pizza/): WebRTC based p2p file transfers in your browser ([source](https://github.com/hariharjeevan/cheezypizza), BSD 3-Clause)
+- [Gridfinity Layout Tool](https://gridfinitylayouttool.com): A tool for planning drawer organization using the Gridfinity modular storage system ([source](https://github.com/andymai/gridfinity-layout-tool), AGPL-3.0)
+- [Giraffile](https://giraffile.pages.dev/): Share files quickly and securely without relying on cloud servers ([source](https://github.com/coffeetron832/Giraffile), MIT)
+- [Webtor.io](https://webtor.io/): seamless torrent streaming and file sharing ([source](https://github.com/webtor-io/web-ui), MIT)
+- [Clip Fish](https://clip.fish/): App for quickly sharing links, text snippets, and files. ([source](https://github.com/clip-fish/web), MIT)
+- [kPaste](https://kpaste.infomaniak.com/): Private end-to-end encrypted pastebin ([source](https://github.com/Infomaniak/kpaste), GPL-3.0)
+- [OwnCardly](https://owncardly.com/): Digital business cards you actually own ([source](https://github.com/kevinwielander/digital-business-cards), MIT)
+- [Texturinator](https://texturinator.buttermilch-dev.de/): Procedural texture and volume generation toolkit for volumetric rendering, terrain generation ([source](https://github.com/MangoButtermilch/texturinator), ?)
+- [Open-RazerKit](https://hamzayslmn.github.io/open-razerkit/): Control your Razer device's RGB, effects, and settings ([source](https://github.com/HamzaYslmn/open-razerkit), Custom)
+- [Pandoc WASM](https://pandoc.github.io/pandoc-wasm/): Convert documents without leaving the browser. ([source](https://github.com/pandoc/pandoc-wasm), MIT)
+- [ToolsAtZero](https://www.toolsatzero.com/): A workbench of 52 everyday utilities (PDF manipulation, image processing, dev tools) ([source](https://github.com/Anirudh-Rao-portfolio/ToolsAtZero), NC)
+- [Oscilloscope Online V2](https://mumarshahbaz.github.io/Oscilloscope-Online-V2/setup.html): Web Serial Plotter with as much customization as possible ([source](https://github.com/MUmarShahbaz/Oscilloscope-Online-V2), ?)
+- [DropSilk](https://www.dropsilk.xyz/): Modern, privacy-focused, peer-to-peer file transfer application built with WebRTC with screen-share and chat functionality ([source](https://github.com/medy17/dropsilk), GPL-3.0)
+- [Daggerheart GM Screen](https://jutier.github.io/Daggerheart/): Daggerheart GM Screen ([source](https://github.com/Jutier/Daggerheart), ?)
+- [Jobber](https://rssjobs.app/): Dynamic Job Search RSS Feed Generator ([source](https://github.com/alwedo/jobber), MIT)
+- [Relay](https://relay.rishishah.in): WebRTC peer-to-peer file transfer ([source](https://github.com/byrishi/Relay), MIT)
+- [zkdrop](https://zkdrop.org): Secure, temporary, and minimal file sharing with zero-knowledge encryption ([source](https://github.com/zedxihan/zkdrop), AGPL-3.0)
+- [xipe](https://xi.pe/): URL shortener and pastebin service ([source](https://github.com/drewstreib/xipe-go), MIT)
+- [Ul0](https://ul0.site): Free URL shortener that lets you create branded short links with custom domains, QR codes, click analytics, and an easy-to-use dashboard ([source](https://github.com/Saketkesar/ul0), ?)
+- [qTransfer](https://transfer-cv5.pages.dev/): Easly connects 2 browsers to transfer files ([source](https://github.com/atlanticsupport/quick-transfer), ?)
+- [enumbers lookup](https://enumbers.jarvisdiscordbot.net/): A modern web application for looking up E-number food additives with comprehensive data from Open Food Facts ([source](https://github.com/JARVIS-discordbot/e-numbers), CC-BY-SA-3.0)
+
+## Data & Analytics
+
+Explore and visualize data locally
+
+- [World Monitor](https://www.worldmonitor.app/): Real-time global intelligence dashboard. AI-powered news aggregation, geopolitical monitoring, and infrastructure tracking in a unified situational awareness interface ([source](https://github.com/koala73/worldmonitor?utm_source=worldmonitor&utm_medium=referral&utm_campaign=general), AGPL-3.0-only)
+- [RAWGraphs](https://app.rawgraphs.io): A web interface to create custom vector-based visualizations on top of RAWGraphs core ([source](https://github.com/rawgraphs/rawgraphs-app), Apache-2.0)
+- [OSIRIS](https://www.osirisai.live/): Open Source Palantir Alternative ([source](https://github.com/simplifaisoul/osiris), MIT)
+- [Mr. Data Converter](https://shancarter.github.io/mr-data-converter/): Takes CSV or tab-delimited data from Excel and converts it into several web-friendly formats, include JSON and XML. ([source](https://github.com/shancarter/Mr-Data-Converter?tab=License-1-ov-file), MIT)
+- [Datasette Lite](https://lite.datasette.io): a full server-side Datasette Python web application directly in your browser ([source](https://github.com/simonw/datasette-lite), Apache-2.0)
+- [SQLChef](https://jonathanwalker.github.io/SQLChef/): Query files like CSV, JSON, and Parquet directly in the browser ([source](https://github.com/jonathanwalker/sqlchef), MIT)
+- [Schema3D](https://schema3d.com/): An interactive tool for visualizing relational database schemas in 3D. ([source](https://github.com/shane-jacobeen/schema3d), MIT)
+- [Satvisor](https://satvisor.com/): 3D satellite tracker with orbit visualization, pass predictions, and antenna rotator control (GS-232, EasyComm, Hamlib) ([source](https://github.com/satvisorcom/satvisor), AGPL-3.0)
+- [Grade Boundaries](https://gradeboundaries.com): A level and IGCSE grade boundary lookup ([source](https://github.com/Grade-Boundaries/GradeBoundaries-stable), CC BY-NC 4.0)
+
+## Media
+
+Edit and create media in-browser
+
+- [OpenCut](https://opencut.app): The open-source CapCut alternative ([source](https://github.com/OpenCut-app/OpenCut), MIT)
+- [Cobalt](https://cobalt.tools/): media downloader that doesn't piss you off. it's friendly, efficient, and doesn't have ads, trackers, paywalls or other nonsense. ([source](https://github.com/imputnet/cobalt), AGPL-3.0)
+- [Squoosh](https://squoosh.app/): Image compression web app that reduces image sizes through numerous formats ([source](https://github.com/GoogleChromeLabs/squoosh/), Apache-2.0)
+- [SubtitleEdit](https://www.nikse.dk/subtitleedit/online): Online Subtitle Editor ([source](https://github.com/SubtitleEdit/subtitleedit), MIT)
+- [OpenReel](https://openreel.video/): Open source CapCut alternative ([source](https://github.com/Augani/openreel-video), MIT)
+- [AudioMass](https://audiomass.co/): Free full-featured web-based audio & waveform editing tool ([source](https://github.com/pkalogiros/AudioMass), MIT)
+- [Image Max URL](https://qsniyg.github.io/maxurl/): Finds larger/original versions of images and videos ([source](https://github.com/qsniyg/maxurl), Apache-2.0)
+- [FreeCut](https://freecut.net): Professional video editing, zero installation. Create stunning content in your browser ([source](https://github.com/walterlow/freecut), MIT)
+- [Openvid](https://openvid.dev/en): Platform designed to transform raw screen recordings into polished, high-quality demonstration videos ([source](https://github.com/CristianOlivera1/openvid), NC)
+- [OmniClip](https://omniclip.app/): Powerful video editor right in your browser ([source](https://github.com/omni-media/omniclip), MIT)
+- [MiNi PhotoEditor](https://mini2-photo-editor.netlify.app/): Online webgl photo editor with effects, filters and cropping ([source](https://github.com/xdadda/mini-photo-editor), MIT)
+- [Wavacity](https://wavacity.com/): Easy-to-use, multi-track audio editor and recorder ([source](https://github.com/ahilss/wavacity), GPL-2.0)
+- [Compress](https://videocompress.prolab.sh/): Say goodbye to bulky files! Crush video sizes by 90% with no quality loss, even offline ([source](https://github.com/pranavp10/video-compress), MIT)
+- [Drumhaus](https://drumha.us/): Computer Controlled Rhythmic Groove Machine ([source](https://github.com/mxfng/drumhaus), CC BY-NC-SA 4.0)
+- [ComposeYogi](https://composeyogi.com/): Ableton-style music composer for the web ([source](https://github.com/AppsYogi-com/ComposeYogi), MIT)
+- [Midee](https://midee.app/): Play, visualize, learn, and export your MIDI music as gorgeous piano-roll videos, entirely client-side with zero uploads. ([source](https://github.com/aayushdutt/midee), ?)
+- [GreenDolphin](https://greendolph.in): Recording looper and analysis tool designed for musicians who want to transcribe music or learn songs by ear ([source](https://github.com/YottaYocta/GreenDolphin), GPL-3.0)
+- [ClearCanvas AI](https://clearcanvasai.vercel.app/): Generate images, compress photos, upscale pictures, and remove backgrounds ([source](https://github.com/rakibulsagor/Clearcanvas), MIT)
+- [s-2-v](https://s-2-v.pages.dev/): A simple collection of video processing tools ([source](https://github.com/kuronekony4n/sequence-to-video), ?)
+
+## Education
+
+Learn and study without creating accounts
+
+- [Roadmaps.sh](https://roadmap.sh/): Interactive roadmaps, guides and other educational content to help developers grow in their careers ([source](https://github.com/nilbuild/developer-roadmap), Custom)
+- [Full Stack open](https://fullstackopen.com/en/): Learn React, Redux, Node.js, MongoDB, GraphQL and TypeScript in one go ([source](https://github.com/fullstack-hy2020/fullstack-hy2020.github.io), CC BY-NC-SA 3.0)
+- [Agora Cosmica](https://agoracosmica.org): Learn from 30 historical figures through stories, dialogues, and AI conversation. Nonprofit, no signup. ([source](https://github.com/chipmates/agoracosmica), AGPL-3.0)
+- [Quizbun](https://a-dev.github.io/quizbun/): static, explanation-first quiz catalog for self-learners, with public quizzes, private local imports, and an AI-first quiz format ([source](https://github.com/a-dev/quizbun), MIT)
+- [The Missing Manual](https://themissingmanual.dev): Clear, in-depth guides to everything from how a computer boots up to how the internet, databases, and AI really work ([source](https://github.com/Topurrra/themissingmanual), CC-BY-SA-4.0)
+
+## Lists
+
+Lists that contain useful information
+
+- [free-for.dev](https://free-for.dev/#/): A list of SaaS, PaaS and IaaS offerings that have free tiers of interest to devops and infradev ([source](https://github.com/ripienaar/free-for-dev), ?)
+- [OSINT Framework](https://osintframework.com/): An open-source, browser-based directory of OSINT tools and resources organized by investigation category. ([source](https://github.com/lockfale/OSINT-Framework), MIT)
+- [freemediaheckyeah](https://fmhy.net/): The largest collection of free stuff on the internet! ([source](https://github.com/fmhy/edit), ?)
+<!-- END GENERATED TOOL LIST -->

--- a/scripts/generateLlmsDocs.mjs
+++ b/scripts/generateLlmsDocs.mjs
@@ -1,0 +1,82 @@
+// Regenerates the tool list embedded in public/llms.txt and AGENTS.md from
+// tools.json. Runs automatically as part of `npm run build`; can also be run
+// directly with `npm run generate:llms`.
+//
+// Both files keep their hand-written prose; this script only rewrites the
+// block between the BEGIN/END GENERATED TOOL LIST markers.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve, dirname, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const BEGIN = "<!-- BEGIN GENERATED TOOL LIST -->";
+const END = "<!-- END GENERATED TOOL LIST -->";
+
+const { categories, tools } = JSON.parse(
+  readFileSync(resolve(ROOT, "tools.json"), "utf8"),
+);
+
+// Mirror the site's sorting: featured first, then by stars.
+function byFeaturedThenStars(a, b) {
+  if (a.featured && !b.featured) return -1;
+  if (!a.featured && b.featured) return 1;
+  return (b.stars ?? 0) - (a.stars ?? 0);
+}
+
+function toolsOf(categoryId) {
+  return tools.filter((t) => t.category === categoryId).sort(byFeaturedThenStars);
+}
+
+// Full list for llms.txt: linked name, description, optional source link,
+// and a warning for tools flagged as not recommended.
+function llmsBlock() {
+  const lines = [
+    `The full directory (${tools.length} tools, ${categories.length} categories) follows. This block is auto-generated from tools.json at build time.`,
+  ];
+  for (const cat of categories) {
+    const catTools = toolsOf(cat.id);
+    if (catTools.length === 0) continue;
+    lines.push("", `## ${cat.name}`, "", cat.description, "");
+    for (const t of catTools) {
+      let line = `- [${t.name}](${t.url}): ${t.description}`;
+      if (t.github) line += ` ([source](${t.github})${t.license ? `, ${t.license}` : ""})`;
+      if (t.notRecommendedReason) line += ` — ⚠️ not recommended: ${t.notRecommendedReason}`;
+      lines.push(line);
+    }
+  }
+  return lines.join("\n");
+}
+
+// Compact index for AGENTS.md: enough to spot duplicates before adding a tool.
+function agentsBlock() {
+  const lines = [
+    `${tools.length} tools across ${categories.length} categories, generated from tools.json. Check here before adding a tool to avoid duplicates.`,
+  ];
+  for (const cat of categories) {
+    const catTools = toolsOf(cat.id);
+    if (catTools.length === 0) continue;
+    lines.push("", `### ${cat.name} (\`${cat.id}\`, ${catTools.length} tools)`, "");
+    for (const t of catTools) {
+      lines.push(`- \`${t.id}\` — [${t.name}](${t.url})`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function injectBlock(path, block) {
+  const src = readFileSync(path, "utf8");
+  const begin = src.indexOf(BEGIN);
+  const end = src.indexOf(END);
+  if (begin === -1 || end === -1 || end < begin) {
+    throw new Error(`Markers "${BEGIN}" / "${END}" not found in ${path}`);
+  }
+  const out =
+    src.slice(0, begin + BEGIN.length) + "\n" + block + "\n" + src.slice(end);
+  writeFileSync(path, out);
+  console.log(`Updated ${relative(ROOT, path)}`);
+}
+
+injectBlock(resolve(ROOT, "public/llms.txt"), llmsBlock());
+injectBlock(resolve(ROOT, "AGENTS.md"), agentsBlock());
+console.log(`Embedded ${tools.length} tools in ${categories.length} categories.`);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,23 @@
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
+import { copyFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// AGENTS.md lives at the repo root (the standard location for coding agents),
+// so copy it into the build output to also serve it at /AGENTS.md.
+function publishAgentsMd(): Plugin {
+  return {
+    name: "publish-agents-md",
+    apply: "build",
+    closeBundle() {
+      copyFileSync(
+        resolve(__dirname, "AGENTS.md"),
+        resolve(__dirname, "dist/AGENTS.md"),
+      );
+    },
+  };
+}
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), publishAgentsMd()],
 });


### PR DESCRIPTION
## What

Makes the directory readable by LLMs and AI coding agents, and adds release hygiene:

- **`public/llms.txt`** — served at `https://nosignups.net/llms.txt` following the [llmstxt.org](https://llmstxt.org) convention. Since the site is a React SPA, an LLM fetching the root URL gets an empty HTML shell; this file summarizes the project **and embeds the complete tool directory** (all 210 tools grouped by category, with links, descriptions, source repos, and licenses), so LLMs can read the whole list in one fetch.
- **`AGENTS.md`** — repo-root instructions for AI coding agents per the [agents.md](https://agents.md) convention: commands, project layout, `tools.json` schema, contribution rules, plus a compact auto-generated tool index so agents can check for duplicates before adding a tool.
- **`scripts/generateLlmsDocs.mjs`** — zero-dependency Node script that regenerates the tool lists in both files from `tools.json` (block between `BEGIN/END GENERATED TOOL LIST` markers; hand-written prose is untouched). Sorting mirrors the site: featured first, then stars. Runs automatically as the first step of `npm run build`, so the published files always reflect the latest `tools.json`; also runnable standalone via `npm run generate:llms`.
- **`vite.config.ts`** — a small build-only plugin that copies `AGENTS.md` into `dist/` so it is also served at `https://nosignups.net/AGENTS.md` (linked from `llms.txt`).
- **`CHANGELOG.md`** — [Keep a Changelog](https://keepachangelog.com) format with [SemVer](https://semver.org) versioning; `1.1.0` covers this PR, `1.0.0` the initial release. Routine `tools.json` edits are explicitly out of its scope.
- **`package.json`** — version bumped `1.0.0` → `1.1.0` (additive, backwards-compatible changes).

## Why

More and more people find tools by asking an LLM. These files let assistants discover and correctly cite the NoSignups directory — including every listed tool — and help coding agents contribute to the repo following your guidelines.

## Verification

- `npm run build` passes; `dist/` contains both `llms.txt` and `AGENTS.md` with all 210 tools embedded.
- Generation is idempotent (running it twice produces byte-identical files).
- No runtime code paths touched — the vite change is build-time only (`apply: "build"`), so `npm run dev` is unaffected.