### PR TITLE
a11y(ToolCard): convert tag spans to interactive buttons with semantic list structure

### DIFF
--- a/src/components/Controls.tsx
+++ b/src/components/Controls.tsx
@@ -69,8 +69,15 @@ export function Controls({
         </div>
 
         <div className="results-count" aria-live="polite">
-          SHOWING {String(filteredCount).padStart(2, "0")} OF{" "}
-          {String(allTools.length).padStart(2, "0")} TOOLS
+          SHOWING{" "}
+          <span className="white">
+            {String(filteredCount).padStart(2, "0")}
+          </span>{" "}
+          OF{" "}
+          <span className="white">
+            {String(allTools.length).padStart(2, "0")}
+          </span>{" "}
+          TOOLS
         </div>
       </div>
     </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,3 +1,4 @@
+import { ExternalIcon } from "../constants/icons";
 import { useModal } from "../hooks/useModal";
 
 export function Footer() {
@@ -27,7 +28,7 @@ export function Footer() {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                Report an issue
+                Report an issue <ExternalIcon />
               </a>
             </div>
           </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -17,7 +17,7 @@ export function Footer() {
             <h3>Contribute</h3>
             <p>
               <button
-                className="footer-link-btn"
+                className="footer-btn"
                 onClick={() => showModalWithID("submit-tool")}
               >
                 Submit a tool

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -15,15 +15,13 @@ export function Footer() {
           </div>
           <div className="footer-col">
             <h3>Contribute</h3>
-            <p>
+            <div className="contribute-buttons">
               <button
                 className="footer-btn"
                 onClick={() => showModalWithID("submit-tool")}
               >
                 Submit a tool
               </button>
-            </p>
-            <p>
               <a
                 href="https://github.com/BraveOPotato/FckSignups/issues/new"
                 target="_blank"
@@ -31,7 +29,7 @@ export function Footer() {
               >
                 Report an issue
               </a>
-            </p>
+            </div>
           </div>
           <div className="footer-col">
             <h3>Legal</h3>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -73,10 +73,16 @@ export function Header({
               SUBMIT A TOOL
             </button>
             <div className="stat-row">
-              {String(toolCount).padStart(3, "0")} TOOLS LOADED
+              <span className="white">
+                {String(toolCount).padStart(3, "0")}
+              </span>{" "}
+              TOOLS LOADED
             </div>
             <div className="stat-row">
-              {String(categoryCount).padStart(3, "0")} CATEGORIES
+              <span className="white">
+                {String(categoryCount).padStart(3, "0")}
+              </span>{" "}
+              CATEGORIES
             </div>
           </div>
         </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,7 +13,7 @@ export function Header({
   setSearchQuery,
 }: HeaderProps) {
   const { showModalWithID } = useModal();
-  const [starsCount, setStarsCount] = useState(0);
+  const [starsCount, setStarsCount] = useState("????");
 
   useEffect(() => {
     fetch("https://api.github.com/repos/BraveOPotato/FckSignups")

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -72,17 +72,21 @@ export function Header({
             >
               SUBMIT A TOOL
             </button>
-            <div className="stat-row">
-              <span className="white">
-                {String(toolCount).padStart(3, "0")}
-              </span>{" "}
-              TOOLS LOADED
-            </div>
-            <div className="stat-row">
-              <span className="white">
-                {String(categoryCount).padStart(3, "0")}
-              </span>{" "}
-              CATEGORIES
+
+            <div className="stats">
+              <div className="stat-row">
+                <span className="white">
+                  {String(toolCount).padStart(3, "0")}
+                </span>{" "}
+                TOOLS LOADED
+              </div>
+              •
+              <div className="stat-row">
+                <span className="white">
+                  {String(categoryCount).padStart(3, "0")}
+                </span>{" "}
+                CATEGORIES
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/ToolCard.tsx
+++ b/src/components/ToolCard.tsx
@@ -104,8 +104,9 @@ export function ToolCard({ tool, category, setSearchQuery }: ToolCardProps) {
 
         <div className="card-tags">
           {tool.tags.map((tag) => (
-            <span
+            <button
               key={tag}
+              type="button"
               className="tag"
               onClick={(e) => {
                 e.stopPropagation();
@@ -113,7 +114,7 @@ export function ToolCard({ tool, category, setSearchQuery }: ToolCardProps) {
               }}
             >
               #{tag}
-            </span>
+            </button>
           ))}
         </div>
 

--- a/src/components/ToolCard.tsx
+++ b/src/components/ToolCard.tsx
@@ -1,10 +1,10 @@
-import type { Tool, Category } from "../types";
-import { ExternalIcon, GitHubIcon, StarIcon } from "../constants/icons";
-import { formatStars } from "../utils/formatters";
-import { useReport } from "../hooks/useReport";
-import { useModal } from "../hooks/useModal";
-import { Toast } from "./Toast";
 import { useState } from "react";
+import { ExternalIcon, GitHubIcon, StarIcon } from "../constants/icons";
+import { useModal } from "../hooks/useModal";
+import { useReport } from "../hooks/useReport";
+import type { Category, Tool } from "../types";
+import { formatStars } from "../utils/formatters";
+import { Toast } from "./Toast";
 
 interface ToolCardProps {
   tool: Tool;
@@ -108,6 +108,7 @@ export function ToolCard({ tool, category, setSearchQuery }: ToolCardProps) {
               key={tag}
               type="button"
               className="tag"
+              aria-label={`Filter tools by ${tag.replace(/-/g, " ")}`}
               onClick={(e) => {
                 e.stopPropagation();
                 setSearchQuery(tag);

--- a/src/components/ToolCard.tsx
+++ b/src/components/ToolCard.tsx
@@ -102,22 +102,23 @@ export function ToolCard({ tool, category, setSearchQuery }: ToolCardProps) {
 
         <p className="card-desc">{tool.description}</p>
 
-        <div className="card-tags">
+        <ul className="card-tags">
           {tool.tags.map((tag) => (
-            <button
-              key={tag}
-              type="button"
-              className="tag"
-              aria-label={`Filter tools by ${tag.replace(/-/g, " ")}`}
-              onClick={(e) => {
-                e.stopPropagation();
-                setSearchQuery(tag);
-              }}
-            >
-              #{tag}
-            </button>
+            <li key={tag}>
+              <button
+                type="button"
+                className="tag"
+                aria-label={`Filter tools by ${tag.replace(/-/g, " ")}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setSearchQuery(tag);
+                }}
+              >
+                #{tag}
+              </button>
+            </li>
           ))}
-        </div>
+        </ul>
 
         <div className="card-footer">
           <div className="footer-left">

--- a/src/index.css
+++ b/src/index.css
@@ -942,6 +942,18 @@ footer {
     width: fit-content;
 }
 
+.contribute-buttons>a {
+    display: flex;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+}
+
+.contribute-buttons>a>svg {
+    width: .7rem;
+    position: relative;
+    left: 2px;
+}
+
 .footer-bottom {
     font-family: var(--font-mono);
     font-size: 0.7rem;

--- a/src/index.css
+++ b/src/index.css
@@ -425,6 +425,18 @@ input[type="search"] {
     transition: all 0.2s;
 }
 
+input[type="search"]::placeholder {
+    transition: color 0.2s;
+}
+
+input[type="search"]:focus::placeholder {
+    color: var(--text);
+}
+
+input[type="search"]::-webkit-search-cancel-button {
+    cursor: pointer;
+}
+
 input[type="text"]:focus {
     border-color: var(--accent);
     box-shadow: 0 0 0 3px rgba(255, 0, 64, 0.1);

--- a/src/index.css
+++ b/src/index.css
@@ -766,6 +766,10 @@ input[type="text"]::placeholder {
     cursor: pointer;
 }
 
+.tag:active {
+    scale: .99;
+}
+
 .card-footer {
     display: flex;
     justify-content: space-between;

--- a/src/index.css
+++ b/src/index.css
@@ -746,6 +746,7 @@ input[type="text"]::placeholder {
     display: flex;
     flex-wrap: wrap;
     gap: 0.4rem;
+    list-style: none;
 }
 
 .tag {

--- a/src/index.css
+++ b/src/index.css
@@ -1314,18 +1314,16 @@ label:has(+ .modal-input[required])::after {
 }
 
 /* Footer link button */
-.footer-link-btn {
+.footer-btn {
     background: none;
     border: none;
     color: inherit;
     font: inherit;
     cursor: pointer;
     padding: 0;
-    text-decoration: underline;
-    text-underline-offset: 3px;
 }
 
-.footer-link-btn:hover {
+.footer-btn:hover {
     color: var(--accent);
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -755,6 +755,7 @@ input[type="text"]::placeholder {
     padding: 0.15rem 0.4rem;
     border: 1px solid var(--border);
     border-radius: 2px;
+    background-color: transparent;
     transition: all 0.15s;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -78,6 +78,10 @@ body::after {
             rgba(0, 0, 0, 0.3) 4px);
 }
 
+.white {
+    color: #fff;
+}
+
 .toast-container {
     max-width: 19rem;
     position: fixed;

--- a/src/index.css
+++ b/src/index.css
@@ -920,7 +920,8 @@ footer {
 }
 
 .footer-col p,
-.footer-col a {
+.footer-col a,
+.footer-col button {
     font-size: 0.85rem;
     color: var(--text-dim);
     text-decoration: none;
@@ -929,6 +930,16 @@ footer {
 
 .footer-col a:hover {
     color: var(--accent);
+}
+
+.contribute-buttons {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+}
+
+.contribute-buttons>* {
+    width: fit-content;
 }
 
 .footer-bottom {

--- a/src/index.css
+++ b/src/index.css
@@ -179,6 +179,15 @@ body::after {
     margin-bottom: 2rem;
 }
 
+.stars-button-container .stars-button {
+    text-decoration: none;
+    width: 74px;
+    text-wrap: nowrap;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
 .stars-button-container .stars-button:hover .star-svg {
     color: black;
 }
@@ -187,6 +196,8 @@ body::after {
     aspect-ratio: 1/1;
     color: var(--text);
     width: 0.7rem;
+    margin-left: 4px;
+    transition-duration: 0.3s;
 }
 
 .header-grid {

--- a/src/index.css
+++ b/src/index.css
@@ -327,6 +327,13 @@ h1 .dotnet {
     gap: 0.5rem;
 }
 
+.stats {
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+    margin-top: .2rem;
+}
+
 .stat-dot {
     width: 6px;
     height: 6px;

--- a/src/index.css
+++ b/src/index.css
@@ -447,31 +447,33 @@ input[type="text"]::placeholder {
     font-size: 0.8rem;
     font-weight: 500;
     font-family: var(--font-mono);
-    transition: all 0.15s;
     user-select: none;
     position: relative;
     overflow: hidden;
+    transition: color 0.15s, border-color 0.15s .35s;
+}
+
+.cat-btn:hover {
+    color: var(--text);
+    border-color: var(--accent);
+    transition: color 0.15s, border-color 0.15s;
 }
 
 .cat-btn::before {
     content: "";
     position: absolute;
     top: 0;
-    left: -100%;
+    left: 0;
+    translate: -101% 0;
     width: 100%;
     height: 100%;
     background: var(--accent);
-    transition: left 0.2s;
     z-index: -1;
-}
-
-.cat-btn:hover {
-    color: var(--text);
-    border-color: var(--accent);
+    transition: translate .2s .2s, opacity .2s;
 }
 
 .cat-btn:hover::before {
-    left: 0;
+    translate: 0;
     opacity: 0.1;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -615,10 +615,6 @@ input[type="text"]::placeholder {
     gap: 0.75rem;
 }
 
-.card-header svg {
-    cursor: help;
-}
-
 .card-title-wrap {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
## Description
This PR addresses an accessibility deficit in the `ToolCard` component where tag elements were previously rendered using non-interactive `<span>` tags. They have been refactored into fully accessible, semantic `<button>` elements wrapped inside an unordered list (`<ul>`), improving both keyboard navigation and screen reader context.

## Key Changes

### Accessibility & Semantics
* **Interactive Elements:** Replaced non-interactive `<span>` tags with native `<button type="button">` elements to support keyboard focus (`Tab`) and execution (`Enter` / `Space`).
* **Screen Reader Context:** Added explicit `aria-label={`Filter tools by ${tag.replace(/-/g, " ")}`}` attributes to clearly communicate the action of each tag button, avoiding raw hash symbol (`#`) vocalization.
* **Semantic List Structure:** Replaced the generic container `<div>` with an unordered list (`<ul className="card-tags">` and `<li>` items). This allows assistive technologies to announce the exact tag count (e.g., *"List of 3 items"*).

### Visual & Micro-Interactions
* **Active State Feedback:** Added an active press state (`:active` transformation/feedback) to provide immediate tactile visual feedback when a user clicks or presses a tag button.

## Verification Checklist
- [x] Verified keyboard navigation (`Tab` focus and `Enter`/`Space` activation) on tags.
- [x] Confirmed event propagation isolation (`e.stopPropagation()`) prevents triggering card-level clicks.
- [x] Tested screen reader tree output for proper list item count and button announcements.