### PR TITLE
Add sort options for tool listings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Footer } from "./components/Home/Footer/Footer";
 import { Header } from "./components/Home/Header/Header";
 import { ReportFloatingWidget } from "./components/Home/ReportFloatingWidget/ReportFloatingWidget";
@@ -9,8 +10,10 @@ import { MODAL_CONFIGS } from "./constants/ModalConfigs";
 import { ModalProvider } from "./hooks/useModal";
 import { ReportProvider } from "./hooks/useReport";
 import { useTools } from "./hooks/useTools";
+import type { SortOption } from "./types";
 
 export default function App() {
+  const [sortBy, setSortBy] = useState<SortOption>("default");
   const {
     tools,
     filteredTools,
@@ -44,8 +47,10 @@ export default function App() {
           searchQuery={searchQuery}
           allTools={tools}
           filteredCount={filteredTools.length}
+          sortBy={sortBy}
           onCategoryChange={setActiveCategory}
           onSearchChange={setSearchQuery}
+          onSortChange={setSortBy}
         />
         {activeCat && activeCat.id !== "all" && (
           <div className="section-divider">
@@ -63,6 +68,7 @@ export default function App() {
             errorMessage={errorMessage}
             searchQuery={searchQuery}
             activeCategory={activeCategory}
+            sortBy={sortBy}
             setSearchQuery={setSearchQuery}
           />
 

--- a/src/components/Home/ToolFilters/ToolFilters.module.css
+++ b/src/components/Home/ToolFilters/ToolFilters.module.css
@@ -148,3 +148,47 @@ input[type="text"]::placeholder {
 	color: var(--text-muted);
 	margin-top: 0.25rem;
 }
+
+.resultsToolbar {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: 1rem;
+}
+
+.sortControls {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	color: var(--text-muted);
+	font-family: var(--font-mono);
+	font-size: 0.7rem;
+	letter-spacing: 0.08em;
+}
+
+.sortSelect {
+	background: var(--surface);
+	color: var(--text);
+	border: 1px solid var(--border-light);
+	border-radius: 4px;
+	padding: 0.35rem 0.6rem;
+	font: inherit;
+	cursor: pointer;
+}
+
+.sortSelect:hover,
+.sortSelect:focus-visible {
+	border-color: var(--accent);
+}
+
+.sortSelect:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: 2px;
+}
+
+@media (max-width: 480px) {
+	.resultsToolbar {
+		align-items: flex-start;
+		flex-direction: column;
+	}
+}

--- a/src/components/Home/ToolFilters/ToolFilters.tsx
+++ b/src/components/Home/ToolFilters/ToolFilters.tsx
@@ -1,4 +1,4 @@
-import type { Category, Tool } from "../../../types";
+import type { Category, SortOption, Tool } from "../../../types";
 import s from "./ToolFilters.module.css";
 
 interface ToolFiltersProps {
@@ -7,8 +7,10 @@ interface ToolFiltersProps {
   searchQuery: string;
   allTools: Tool[];
   filteredCount: number;
+  sortBy: SortOption;
   onCategoryChange: (id: string) => void;
   onSearchChange: (q: string) => void;
+  onSortChange: (sort: SortOption) => void;
 }
 
 export function ToolFilters({
@@ -17,8 +19,10 @@ export function ToolFilters({
   searchQuery,
   allTools,
   filteredCount,
+  sortBy,
   onCategoryChange,
   onSearchChange,
+  onSortChange,
 }: ToolFiltersProps) {
   // Count tools per category for badge
   const counts: Record<string, number> = { all: allTools.length };
@@ -69,16 +73,34 @@ export function ToolFilters({
           })}
         </div>
 
-        <div className={s.resultsCount} aria-live="polite">
-          SHOWING{" "}
-          <span className="white">
-            {String(filteredCount).padStart(2, "0")}
-          </span>{" "}
-          OF{" "}
-          <span className="white">
-            {String(allTools.length).padStart(2, "0")}
-          </span>{" "}
-          TOOLS
+        <div className={s.resultsToolbar}>
+          <div className={s.resultsCount} aria-live="polite">
+            SHOWING{" "}
+            <span className="white">
+              {String(filteredCount).padStart(2, "0")}
+            </span>{" "}
+            OF{" "}
+            <span className="white">
+              {String(allTools.length).padStart(2, "0")}
+            </span>{" "}
+            TOOLS
+          </div>
+
+          <div className={s.sortControls}>
+            <label htmlFor="sort-select">SORT BY</label>
+            <select
+              id="sort-select"
+              className={s.sortSelect}
+              value={sortBy}
+              onChange={(event) =>
+                onSortChange(event.target.value as SortOption)
+              }
+            >
+              <option value="default">Default</option>
+              <option value="newest">Newest</option>
+              <option value="oldest">Oldest</option>
+            </select>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/Home/Tools/Tools.tsx
+++ b/src/components/Home/Tools/Tools.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useState } from "react";
 import type { ToolSections } from "../../../hooks/useTools";
-import type { Category, LoadStatus, Tool } from "../../../types";
+import type {
+  Category,
+  LoadStatus,
+  SortOption,
+  Tool,
+} from "../../../types";
 import ShowMoreButton from "../../Shared/Buttons/ShowMoreButton/ShowMoreButton";
 import { ToolCard } from "./ToolCard/ToolCard";
 import s from "./Tools.module.css";
@@ -14,6 +19,7 @@ interface ToolsProps {
   errorMessage: string;
   searchQuery: string;
   activeCategory: string;
+  sortBy: SortOption;
   setSearchQuery: (query: string) => void;
 }
 
@@ -32,13 +38,14 @@ export function Tools({
   errorMessage,
   searchQuery,
   activeCategory,
+  sortBy,
   setSearchQuery,
 }: ToolsProps) {
   const [showMore, setShowMore] = useState(false);
 
   useEffect(() => {
     setShowMore(false);
-  }, [searchQuery, activeCategory]);
+  }, [searchQuery, activeCategory, sortBy]);
 
   if (loadStatus === "loading") {
     return (
@@ -86,6 +93,7 @@ export function Tools({
             categories={categories}
             searchKeywords={searchKeywords}
             setSearchQuery={setSearchQuery}
+            sortBy={sortBy}
           />
         )}
 
@@ -97,6 +105,7 @@ export function Tools({
             categories={categories}
             searchKeywords={searchKeywords}
             setSearchQuery={setSearchQuery}
+            sortBy={sortBy}
           />
         )}
 
@@ -109,6 +118,7 @@ export function Tools({
               categories={categories}
               searchKeywords={searchKeywords}
               setSearchQuery={setSearchQuery}
+              sortBy={sortBy}
             />
           ) : (
             <ShowMoreButton
@@ -128,6 +138,7 @@ interface ToolsSectionProps {
   categories: Category[];
   searchKeywords: string[];
   setSearchQuery: (query: string) => void;
+  sortBy: SortOption;
 }
 
 function ToolsSection({
@@ -137,13 +148,29 @@ function ToolsSection({
   categories,
   searchKeywords,
   setSearchQuery,
+  sortBy,
 }: ToolsSectionProps) {
+  const sortedTools = [...tools].sort((left, right) => {
+    if (sortBy === "default") return 0;
+
+    const leftTime = left.addedAt ? Date.parse(left.addedAt) : Number.NaN;
+    const rightTime = right.addedAt ? Date.parse(right.addedAt) : Number.NaN;
+    const leftHasDate = Number.isFinite(leftTime);
+    const rightHasDate = Number.isFinite(rightTime);
+
+    if (!leftHasDate && !rightHasDate) return 0;
+    if (!leftHasDate) return 1;
+    if (!rightHasDate) return -1;
+
+    return sortBy === "newest" ? rightTime - leftTime : leftTime - rightTime;
+  });
+
   return (
     <section className={`${s.toolSection} ${sectionVariantClass[variant]}`}>
       <div className={s.sectionDivider}>{label}</div>
 
       <div className={s.grid}>
-        {tools.map((tool) => (
+        {sortedTools.map((tool) => (
           <ToolCard
             key={tool.id}
             tool={tool}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,8 @@ export type ToolSection = "featured" | "editors-pick" | "meets-criteria";
 
 export type ToolFlag = "new" | "abandoned";
 
+export type SortOption = "default" | "newest" | "oldest";
+
 export interface Tool {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary

This PR adds a "Sort by" dropdown to the tool listings.

### Changes
- Added Default, Newest, and Oldest sorting options.
- Preserved the original order as the default.
- Integrated the sort control with the existing toolbar.