### PR TITLE
feat(a11y): add SkipContentLink component for keyboard navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Footer } from "./components/Footer";
 import { Header } from "./components/Header";
 import { Report } from "./components/Report";
 import { ScrollToTopButton } from "./components/ScrollToTopButton";
+import SkipContentLink from "./components/SkipContentLink";
 import { ToolGrid } from "./components/ToolGrid";
 import { MODAL_CONFIGS } from "./constants/ModalConfigs";
 import { ModalProvider } from "./hooks/useModal";
@@ -30,6 +31,7 @@ export default function App() {
   return (
     <>
       <ModalProvider modalConfigs={MODAL_CONFIGS}>
+        <SkipContentLink />
         <Header
           toolCount={tools.length}
           categoryCount={Math.max(0, categories.length - 1)}

--- a/src/components/SkipContentLink.tsx
+++ b/src/components/SkipContentLink.tsx
@@ -1,0 +1,9 @@
+const SkipContentLink = () => {
+  return (
+    <a className="skip-link" href="#main-content" target="_self">
+      Skip to main content
+    </a>
+  );
+};
+
+export default SkipContentLink;

--- a/src/components/ToolGrid.tsx
+++ b/src/components/ToolGrid.tsx
@@ -60,7 +60,7 @@ export function ToolGrid({
   const meetsExpanded = !hasCurated || showMore;
 
   return (
-    <main className="tool-sections">
+    <main className="tool-sections" id="main-content">
       {loadStatus == "error" && (
         <div className="error">
           <h3>ERR_LOAD_FAILED</h3>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -44,6 +44,37 @@ body {
     overflow-x: hidden;
 }
 
+.skip-link {
+    position: fixed;
+    top: 0;
+    left: 50%;
+    z-index: 10000;
+    padding: 1rem;
+    background: var(--accent);
+    color: var(--text);
+    border-radius: .75rem;
+    text-decoration: none;
+    font-weight: 600;
+    font-size: .9rem;
+    letter-spacing: .03em;
+    text-transform: uppercase;
+    translate: -50% -101%;
+    transition: translate 180ms ease;
+}
+
+@media (max-width: 768px) {
+    .skip-link {
+        font-size: .8rem;
+        padding: .8rem;
+        border-radius: .5rem;
+    }
+}
+
+.skip-link:focus,
+.skip-link:focus-visible {
+    translate: -50% 20px;
+}
+
 /* ===== NOISE OVERLAY ===== */
 body::before {
     content: "";


### PR DESCRIPTION
## Summary
Adds a `SkipContentLink` component to allow keyboard users to skip directly to the main content area.

## Changes
* Created `SkipContentLink` component targeting `#main-content`.
* Styled the component to match the website theme.
* Added standard focus styles to ensure high visibility when navigating via keyboard.

## Testing
* Verified keyboard navigation (`Tab` key brings up the link as the first focusable element).
* Confirmed activating the link jumps directly to the main content target.