### PR TITLE
Add Nutilz Binary Calculator to Utilities

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -4064,6 +4064,22 @@
       "stars": 1948,
       "addedAt": "2026-08-03",
       "section": "editors-pick"
+    },
+    {
+      "id": "nutilz-binary-calculator",
+      "name": "Nutilz Binary Calculator",
+      "description": "Binary arithmetic and bitwise ops (AND/OR/XOR/NOT) with live decimal/hex conversion",
+      "url": "https://nutilz.com/binary-calculator",
+      "category": "utilities",
+      "tags": [
+        "binary",
+        "calculator",
+        "converter",
+        "hex",
+        "developer"
+      ],
+      "addedAt": "2026-08-05",
+      "section": "meets-criteria"
     }
   ]
 }


### PR DESCRIPTION
Adds [Nutilz Binary Calculator](https://nutilz.com/binary-calculator) — a free, browser-only tool for binary arithmetic (add/subtract/multiply/divide), bitwise operations (AND/OR/XOR/NOT), and live decimal/hex conversion. No signup required, runs entirely client-side. Added to the Utilities category following the existing `tools.json` schema and using the standard `meets-criteria` section like other community submissions.