### PR TITLE
feat: add Taskuary interactive demo

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -4239,6 +4239,25 @@
       "stars": 17,
       "addedAt": "2026-08-21",
       "section": "meets-criteria"
+    },
+    {
+      "id": "taskuary",
+      "name": "Taskuary",
+      "description": "Explore a local-first AI task hub for triage, reports, and coding-agent handoffs in an interactive browser demo.",
+      "url": "https://taskuary.com/demo/",
+      "category": "productivity",
+      "tags": [
+        "ai",
+        "task-management",
+        "automation",
+        "email",
+        "coding-agents"
+      ],
+      "github": "https://github.com/ldbumble/taskuary",
+      "license": "MIT",
+      "stars": 48,
+      "addedAt": "2026-09-07",
+      "section": "meets-criteria"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- add Taskuary to the Productivity directory
- link directly to its no-signup interactive browser demo
- include the public MIT-licensed source repository and searchable tags

## Why it fits

- **No signup:** the demo opens directly with fictional data and does not request an account.
- **In browser:** the hosted demo runs in the browser with no install.
- **Open source:** Taskuary is MIT licensed at https://github.com/ldbumble/taskuary.

The listing describes the hosted experience as an interactive demo so visitors can distinguish it from the locally installed app that connects real services.

## Validation

- parsed tools.json and checked the ID is unique
- checked the category, 3-5 tag rule, and description length (112 characters)
- npm production build passed under Node 22